### PR TITLE
Fix source to be compatible with java 7

### DIFF
--- a/src/main/java/jcifs/ResourceNameFilter.java
+++ b/src/main/java/jcifs/ResourceNameFilter.java
@@ -24,7 +24,6 @@ package jcifs;
  * @author mbechler
  *
  */
-@FunctionalInterface
 public interface ResourceNameFilter {
 
     /**

--- a/src/main/java/jcifs/internal/util/StringUtil.java
+++ b/src/main/java/jcifs/internal/util/StringUtil.java
@@ -1,5 +1,5 @@
 /*
- * © 2017 AgNO3 Gmbh & Co. KG
+ * © 2017 Matthias Bläsing <mblaesing@doppel-helix.eu>
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -15,23 +15,29 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
-package jcifs;
 
+package jcifs.internal.util;
 
-/**
- * Filter based on a resource instance
- * 
- * @author mbechler
- *
- */
-public interface ResourceFilter {
-
+public class StringUtil {
     /**
+     * Implementation of {@link java.lang.String#join} backported for JDK7.
      * 
-     * @param resource
-     * @return whether the given resource should be included
-     * @throws CIFSException
+     * @param delimiter
+     * @param elements
+     * @return 
      */
-    public boolean accept ( SmbResource resource ) throws CIFSException;
-
+    public static String join(CharSequence delimiter, CharSequence... elements) {
+        StringBuilder sb = new StringBuilder();
+        for(CharSequence element: elements) {
+            if(sb.length() > 0) {
+                if(delimiter != null) {
+                    sb.append(delimiter);
+                } else {
+                    sb.append("null");
+                }
+            }
+            sb.append(element);
+        }
+        return sb.toString();
+    }
 }

--- a/src/main/java/jcifs/smb/DirFileEntryEnumIteratorBase.java
+++ b/src/main/java/jcifs/smb/DirFileEntryEnumIteratorBase.java
@@ -239,4 +239,8 @@ public abstract class DirFileEntryEnumIteratorBase implements CloseableIterator<
         }
     }
 
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException("remove");
+    }
 }

--- a/src/main/java/jcifs/smb/FileEntryAdapterIterator.java
+++ b/src/main/java/jcifs/smb/FileEntryAdapterIterator.java
@@ -135,4 +135,8 @@ abstract class FileEntryAdapterIterator implements CloseableIterator<SmbResource
         this.delegate.close();
     }
 
+    @Override
+    public void remove() {
+        this.delegate.remove();
+    }
 }

--- a/src/main/java/jcifs/smb/NetServerEnumIterator.java
+++ b/src/main/java/jcifs/smb/NetServerEnumIterator.java
@@ -207,4 +207,8 @@ public class NetServerEnumIterator implements CloseableIterator<FileEntry> {
         this.next = null;
     }
 
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException("remove");
+    }
 }

--- a/src/main/java/jcifs/smb/ShareEnumIterator.java
+++ b/src/main/java/jcifs/smb/ShareEnumIterator.java
@@ -129,4 +129,8 @@ class ShareEnumIterator implements CloseableIterator<SmbResource> {
         this.next = null;
     }
 
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException("remove");
+    }
 }

--- a/src/main/java/jcifs/smb/SmbResourceLocatorImpl.java
+++ b/src/main/java/jcifs/smb/SmbResourceLocatorImpl.java
@@ -31,6 +31,7 @@ import jcifs.DfsReferralData;
 import jcifs.NetbiosAddress;
 import jcifs.SmbConstants;
 import jcifs.SmbResourceLocator;
+import jcifs.internal.util.StringUtil;
 import jcifs.netbios.NbtAddress;
 import jcifs.netbios.UniAddress;
 
@@ -137,8 +138,8 @@ class SmbResourceLocatorImpl implements SmbResourceLocatorInternal, Cloneable {
             if ( nameParts.length > pos ) {
                 String[] remainParts = new String[nameParts.length - pos];
                 System.arraycopy(nameParts, pos, remainParts, 0, nameParts.length - pos);
-                this.unc = "\\" + String.join("\\", remainParts) + ( trailingSlash ? "\\" : "" );
-                this.canon = "/" + this.share + "/" + String.join("/", remainParts) + ( trailingSlash ? "/" : "" );
+                this.unc = "\\" + StringUtil.join("\\", remainParts) + ( trailingSlash ? "\\" : "" );
+                this.canon = "/" + this.share + "/" + StringUtil.join("/", remainParts) + ( trailingSlash ? "/" : "" );
             }
             else {
                 this.unc = "\\";

--- a/src/main/java/jcifs/smb/SmbTransportPoolImpl.java
+++ b/src/main/java/jcifs/smb/SmbTransportPoolImpl.java
@@ -177,8 +177,14 @@ public class SmbTransportPoolImpl implements SmbTransportPool {
 
             @Override
             public int compare ( Address o1, Address o2 ) {
-                int fail1 = SmbTransportPoolImpl.this.failCounts.getOrDefault(o1.getHostAddress(), 0);
-                int fail2 = SmbTransportPoolImpl.this.failCounts.getOrDefault(o2.getHostAddress(), 0);
+                Integer fail1 = SmbTransportPoolImpl.this.failCounts.get(o1.getHostAddress());
+                Integer fail2 = SmbTransportPoolImpl.this.failCounts.get(o2.getHostAddress());
+                if(fail1 == null) {
+                    fail1 = 0;
+                }
+                if(fail2 == null) {
+                    fail2 = 0;
+                }
                 return Integer.compare(fail1, fail2);
             }
 
@@ -214,7 +220,12 @@ public class SmbTransportPoolImpl implements SmbTransportPool {
             }
             catch ( IOException e ) {
                 String hostAddress = addr.getHostAddress();
-                this.failCounts.put(hostAddress, this.failCounts.getOrDefault(hostAddress, 0) + 1);
+                Integer failCount = this.failCounts.get(hostAddress);
+                if(failCount == null) {
+                    this.failCounts.put(hostAddress, 1);
+                } else {
+                    this.failCounts.put(hostAddress, failCount + 1);
+                }
                 ex = e;
             }
         }

--- a/src/test/java/jcifs/tests/AllTests.java
+++ b/src/test/java/jcifs/tests/AllTests.java
@@ -215,7 +215,8 @@ public class AllTests {
 
         if ( System.getProperties().containsKey(TestProperties.TEST_CONFIG_DIR) ) {
             try {
-                Iterator<Path> it = Files.list(Paths.get(System.getProperty(TestProperties.TEST_CONFIG_DIR))).iterator();
+                Path configDir = Paths.get(System.getProperty(TestProperties.TEST_CONFIG_DIR));
+                Iterator<Path> it = Files.newDirectoryStream(configDir).iterator();
 
                 while ( it.hasNext() ) {
                     Path config = it.next();


### PR DESCRIPTION
- FunctionalInterface was added in java 8 
  (it is informative, so removing is not a regression)
- String#join was added in the java 8 cycle, a local implementation was 
  added
- Iterator#remove gained a default implementation in java 8, which
  was not present in java 7
- Files#list was added in java 8