### PR TITLE
Support IBM JDK in Kerb5Context#getSigningKey using Reflection

### DIFF
--- a/src/main/java/jcifs/smb/Kerb5Context.java
+++ b/src/main/java/jcifs/smb/Kerb5Context.java
@@ -17,6 +17,8 @@
 package jcifs.smb;
 
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.security.Key;
 
 import javax.security.auth.Subject;
@@ -30,9 +32,6 @@ import org.ietf.jgss.GSSName;
 import org.ietf.jgss.Oid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.sun.security.jgss.ExtendedGSSContext;
-import com.sun.security.jgss.InquireType;
 
 import jcifs.spnego.NegTokenInit;
 
@@ -186,15 +185,28 @@ class Kerb5Context implements SSPContext {
      */
     @Override
     public byte[] getSigningKey () throws SmbException {
-        ExtendedGSSContext gss = (ExtendedGSSContext) this.gssContext;
-        try {
-            Key k = (Key) gss.inquireSecContext(InquireType.KRB5_GET_SESSION_KEY);
-            return k.getEncoded();
+        /*
+        The kerberos session key is not accessible via the JGSS API. IBM and 
+        Oracle both implement a similar API to make an ExtendedGSSContext
+        available. That API is accessed via reflection to make this independend
+        of the runtime JRE
+        */
+        if( extendedGSSContextClass == null 
+                || inquireSecContext == null 
+                || inquireTypeSessionKey == null) {
+            throw new SmbException("ExtendedGSSContext support not available from JRE");
+        } else {
+            if(extendedGSSContextClass.isAssignableFrom(gssContext.getClass())) {
+                try {
+                    Key k = (Key) inquireSecContext.invoke(gssContext, new Object[]{inquireTypeSessionKey});
+                    return k.getEncoded();
+                } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
+                    throw new SmbException("Failed to query Kerberos session key from ExtendedGSSContext", ex);
+                }
+            } else {
+                throw new SmbException("ExtendedGSSContext is not implemented by GSSContext");
+            }
         }
-        catch ( GSSException e ) {
-            throw new SmbException("Failed to get session key", e);
-        }
-
     }
 
 
@@ -253,6 +265,65 @@ class Kerb5Context implements SSPContext {
             }
             catch ( GSSException e ) {
                 throw new SmbException("Context disposal failed", e);
+            }
+        }
+    }
+    
+    /*
+     * Prepare reflective access to ExtendedGSSContext. The reflective access
+     * abstracts the acces so far, that Oracle JDK, Open JDK and IBM JDK are
+     * supported.
+     * 
+     * At the time of the first implementation only a test on Oracle JDK was
+     * done.
+     */
+
+    private static final String OPENJDK_JGSS_INQUIRE_TYPE_CLASS = "com.sun.security.jgss.InquireType";
+    private static final String OPENJDK_JGSS_EXT_GSSCTX_CLASS = "com.sun.security.jgss.ExtendedGSSContext";
+    
+    private static final String IBM_JGSS_INQUIRE_TYPE_CLASS = "com.ibm.security.jgss.InquireType";
+    private static final String IBM_JGSS_EXT_GSSCTX_CLASS = "com.ibm.security.jgss.ExtendedGSSContext";
+    
+    private final static Class extendedGSSContextClass;
+    private final static Method inquireSecContext;
+    private final static Object inquireTypeSessionKey;
+    
+    static {
+        Class extendedGSSContextClassPrep = null;
+        Method inquireSecContextPrep = null;
+        Object inquireTypeSessionKeyPrep = null;
+        
+        if (extendedGSSContextClassPrep == null || inquireSecContextPrep == null || inquireTypeSessionKeyPrep == null) {
+            try {
+                extendedGSSContextClassPrep = Class.forName(OPENJDK_JGSS_EXT_GSSCTX_CLASS);
+                Class inquireTypeClass = Class.forName(OPENJDK_JGSS_INQUIRE_TYPE_CLASS);
+                inquireSecContextPrep = extendedGSSContextClassPrep.getMethod("inquireSecContext", inquireTypeClass);
+                inquireTypeSessionKeyPrep = Enum.valueOf(inquireTypeClass, "KRB5_GET_SESSION_KEY");
+            } catch (ClassNotFoundException | NoSuchMethodException | SecurityException ex) {
+                if ( log.isDebugEnabled() ) {
+                    log.debug("Failed to initalize ExtendedGSSContext initializdation for OracleJDK / OpenJDK", ex); 
+                }
+            }
+        }
+        if (extendedGSSContextClassPrep == null || inquireSecContextPrep == null || inquireTypeSessionKeyPrep == null) {
+            try {
+                extendedGSSContextClassPrep = Class.forName(IBM_JGSS_EXT_GSSCTX_CLASS);
+                Class inquireTypeClass = Class.forName(IBM_JGSS_INQUIRE_TYPE_CLASS);
+                inquireSecContextPrep = extendedGSSContextClassPrep.getMethod("inquireSecContext", inquireTypeClass);
+                inquireTypeSessionKeyPrep = Enum.valueOf(inquireTypeClass, "KRB5_GET_SESSION_KEY");
+            } catch (ClassNotFoundException | NoSuchMethodException | SecurityException ex) {
+                if ( log.isDebugEnabled() ) {
+                    log.debug("Failed to initalize ExtendedGSSContext initializdation for IBM JDK", ex); 
+                }
+            }
+        }
+        extendedGSSContextClass = extendedGSSContextClassPrep;
+        inquireSecContext = inquireSecContextPrep;
+        inquireTypeSessionKey = inquireTypeSessionKeyPrep;
+        
+        if (extendedGSSContextClass != null && inquireSecContext != null && inquireTypeSessionKey != null) {
+            if ( log.isDebugEnabled() ) {
+                    log.debug("Found ExtendedGSSContext implementation: " + extendedGSSContextClass.getName()); 
             }
         }
     }


### PR DESCRIPTION
The kerberos session key is not accessible via the JGSS API. IBM and 
Oracle both implement a similar API to make an ExtendedGSSContext
available. That API is accessed via reflection to make this independend
of the runtime JRE