### PR TITLE
Remove uncessary direct dependency on hamcrest-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,12 +93,6 @@
 			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-core</artifactId>
-			<version>1.3</version>
-		</dependency>
-
 	</dependencies>
 	<build>
 		<plugins>


### PR DESCRIPTION
hamcrest-core was declared as a direct dependency. As hamcrest-core is
already a transitive dependency via junit, the explizit dependency
can be dropped completely.