### PR TITLE
Fix typos - in comments but also in public method

### DIFF
--- a/src/main/java/jcifs/ACE.java
+++ b/src/main/java/jcifs/ACE.java
@@ -167,7 +167,7 @@ public interface ACE {
 
 
     /**
-     * Returns the access mask accociated with this ACE. Use the
+     * Returns the access mask associated with this ACE. Use the
      * constants for <tt>FILE_READ_DATA</tt>, <tt>FILE_WRITE_DATA</tt>,
      * <tt>READ_CONTROL</tt>, <tt>GENERIC_ALL</tt>, etc with bitwise
      * operators to determine which bits of the mask are on or off.

--- a/src/main/java/jcifs/CIFSContext.java
+++ b/src/main/java/jcifs/CIFSContext.java
@@ -28,14 +28,14 @@ import java.net.URLStreamHandler;
  * A context holds the client configuration, shared services as well as the active credentials.
  * 
  * Usually you will want to create one context per client configuration and then
- * multiple sub-contexts using different credentials (if neccessary).
+ * multiple sub-contexts using different credentials (if necessary).
  * 
  * {@link #withDefaultCredentials()}, {@link #withAnonymousCredentials()}, {@link #withCredentials(Credentials)}
  * allow to create such sub-contexts.
  * 
  * 
  * Implementors of this interface should extend {@link jcifs.context.BaseContext} or
- * {@link jcifs.context.CIFSContextWrapper} to get forward compatability.
+ * {@link jcifs.context.CIFSContextWrapper} to get forward compatibility.
  * 
  * @author mbechler
  *

--- a/src/main/java/jcifs/Config.java
+++ b/src/main/java/jcifs/Config.java
@@ -31,15 +31,15 @@ import jcifs.context.SingletonContext;
 
 
 /**
- * This class now contains only utlities for config parsing.
+ * This class now contains only utilities for config parsing.
  * 
- * We strongly suggest that you create an explicit {@link jcifs.context.CIFSContext}
+ * We strongly suggest that you create an explicit {@link jcifs.context.CIFSContextWrapper}
  * with your desired config. It's base implementation {@link jcifs.context.BaseContext}
  * should be sufficient for most needs.
  * 
  * If you want to retain the classic singleton behavior you can use
  * {@link jcifs.context.SingletonContext#getInstance()}
- * witch is intialized using system properties.
+ * witch is initialized using system properties.
  * 
  */
 @SuppressWarnings ( "javadoc" )
@@ -176,8 +176,8 @@ public class Config {
 
     /**
      * Retrieve an array of <tt>InetAddress</tt> created from a property
-     * value containting a <tt>delim</tt> separated list of hostnames and/or
-     * ipaddresses.
+     * value containing a <tt>delim</tt> separated list of host names and/or
+     * ip addresses.
      */
     public static InetAddress[] getInetAddressArray ( Properties props, String key, String delim, InetAddress[] def ) {
         String p = props.getProperty(key);

--- a/src/main/java/jcifs/Configuration.java
+++ b/src/main/java/jcifs/Configuration.java
@@ -28,7 +28,7 @@ import java.util.TimeZone;
  * 
  * 
  * Implementors of this interface should extend {@link jcifs.config.BaseConfiguration} or
- * {@link jcifs.config.DelegatingConfiguration} to get forward compatability.
+ * {@link jcifs.config.DelegatingConfiguration} to get forward compatibility.
  * 
  * @author mbechler
  *

--- a/src/main/java/jcifs/Configuration.java
+++ b/src/main/java/jcifs/Configuration.java
@@ -190,9 +190,20 @@ public interface Configuration {
      * 
      * Property <tt>jcifs.smb.client.rcv_buf_size</tt> (int, default 65535)
      * 
-     * @return recieve buffer size, in bytes
+     * @return receive buffer size, in bytes
+     * @deprecated use getReceiveBufferSize instead
      */
+    @Deprecated
     int getRecieveBufferSize ();
+
+
+    /**
+     * 
+     * Property <tt>jcifs.smb.client.rcv_buf_size</tt> (int, default 65535)
+     * 
+     * @return receive buffer size, in bytes
+     */
+    int getReceiveBufferSize ();
 
 
     /**

--- a/src/main/java/jcifs/DfsReferralData.java
+++ b/src/main/java/jcifs/DfsReferralData.java
@@ -62,7 +62,7 @@ public interface DfsReferralData {
 
 
     /**
-     * @return the replacement path for this referall
+     * @return the replacement path for this referal
      */
     String getPath ();
 

--- a/src/main/java/jcifs/FileNotifyInformation.java
+++ b/src/main/java/jcifs/FileNotifyInformation.java
@@ -114,7 +114,7 @@ public interface FileNotifyInformation {
      */
     public static final int FILE_ACTION_REMOVED = 0x00000002;
     /**
-     * File has been modifed
+     * File has been modified
      */
     public static final int FILE_ACTION_MODIFIED = 0x00000003;
 

--- a/src/main/java/jcifs/NameServiceClient.java
+++ b/src/main/java/jcifs/NameServiceClient.java
@@ -44,7 +44,7 @@ public interface NameServiceClient {
 
 
     /**
-     * @return the numknown name
+     * @return the unknown name
      */
     NetbiosName getUnknownName ();
 
@@ -121,7 +121,7 @@ public interface NameServiceClient {
     /**
      * Determines the address of a host given it's host name. NetBIOS
      * names also have a <code>type</code>. Types(aka Hex Codes)
-     * are used to distiquish the various services on a host. <a
+     * are used to distinguish the various services on a host. <a
      * href="../../../nbtcodes.html">Here</a> is
      * a fairly complete list of NetBIOS hex codes. Scope is not used but is
      * still functional in other NetBIOS products and so for completeness it has been
@@ -150,7 +150,7 @@ public interface NameServiceClient {
     /**
      * Determines the address of a host given it's host name. NetBIOS
      * names also have a <code>type</code>. Types(aka Hex Codes)
-     * are used to distiquish the various services on a host. <a
+     * are used to distinguish the various services on a host. <a
      * href="../../../nbtcodes.html">Here</a> is
      * a fairly complete list of NetBIOS hex codes. Scope is not used but is
      * still functional in other NetBIOS products and so for completeness it has been
@@ -207,7 +207,7 @@ public interface NameServiceClient {
     /**
      * Lookup <tt>hostname</tt> and return it's <tt>UniAddress</tt>. If the
      * <tt>possibleNTDomainOrWorkgroup</tt> parameter is <tt>true</tt> an
-     * addtional name query will be performed to locate a master browser.
+     * additional name query will be performed to locate a master browser.
      * 
      * @param hostname
      * @param possibleNTDomainOrWorkgroup

--- a/src/main/java/jcifs/NetbiosAddress.java
+++ b/src/main/java/jcifs/NetbiosAddress.java
@@ -141,7 +141,7 @@ public interface NetbiosAddress extends Address {
      * 
      * @param tc
      *            context to use
-     * @return whether this adress is active
+     * @return whether this address is active
      *
      * @throws UnknownHostException
      *             if the host cannot be resolved to find out.

--- a/src/main/java/jcifs/SID.java
+++ b/src/main/java/jcifs/SID.java
@@ -142,7 +142,7 @@ public interface SID {
 
 
     /**
-     * Return text represeting the SID type suitable for display to
+     * Return text representing the SID type suitable for display to
      * users. Text includes 'User', 'Domain group', 'Local group', etc.
      * 
      * @return textual representation of type

--- a/src/main/java/jcifs/SidResolver.java
+++ b/src/main/java/jcifs/SidResolver.java
@@ -97,7 +97,7 @@ public interface SidResolver {
      * This method is designed to assist with computing access control for a
      * given user when the target object's ACL has local groups. Local groups
      * are not listed in a user's group membership (e.g. as represented by the
-     * tokenGroups constructed attribute retrived via LDAP).
+     * tokenGroups constructed attribute retrieved via LDAP).
      * <p/>
      * Domain groups nested inside a local group are currently not expanded. In
      * this case the key (SID) type will be SID_TYPE_DOM_GRP rather than

--- a/src/main/java/jcifs/SmbResource.java
+++ b/src/main/java/jcifs/SmbResource.java
@@ -46,7 +46,7 @@ public interface SmbResource extends AutoCloseable {
     /**
      * The context this file was opened with
      * 
-     * @return the context assoicated with this file
+     * @return the context associated with this file
      */
     CIFSContext getContext ();
 
@@ -213,7 +213,7 @@ public interface SmbResource extends AutoCloseable {
 
 
     /**
-     * Set the last accesss time of the file. The time is specified as milliseconds
+     * Set the last access time of the file. The time is specified as milliseconds
      * from Jan 1, 1970 which is the same as that which is returned by the
      * <tt>lastModified()</tt>, <tt>getLastModified()</tt>, and <tt>getDate()</tt> methods.
      * <br>
@@ -300,7 +300,7 @@ public interface SmbResource extends AutoCloseable {
 
     /**
      * Create a new file but fail if it already exists. The check for
-     * existance of the file and it's creation are an atomic operation with
+     * existence of the file and it's creation are an atomic operation with
      * respect to other filesystem activities.
      * 
      * @throws CIFSException
@@ -380,7 +380,7 @@ public interface SmbResource extends AutoCloseable {
      * <tt>SmbResource</tt> and it's sub-contents to the location specified by the
      * <tt>dest</tt> parameter. This file and the destination file do not
      * need to be on the same host. This operation does not copy extended
-     * file attibutes such as ACLs but it does copy regular attributes as
+     * file attributes such as ACLs but it does copy regular attributes as
      * well as create and last write times. This method is almost twice as
      * efficient as manually copying as it employs an additional write
      * thread to read and write data concurrently.
@@ -399,7 +399,7 @@ public interface SmbResource extends AutoCloseable {
      * Changes the name of the file this <code>SmbResource</code> represents to the name
      * designated by the <code>SmbResource</code> argument.
      * <br>
-     * <i>Remember: <code>SmbResource</code>s are immutible and therefore
+     * <i>Remember: <code>SmbResource</code>s are immutable and therefore
      * the path associated with this <code>SmbResource</code> object will not
      * change). To access the renamed file it is necessary to construct a
      * new <tt>SmbResource</tt></i>.
@@ -417,7 +417,7 @@ public interface SmbResource extends AutoCloseable {
      * Changes the name of the file this <code>SmbResource</code> represents to the name
      * designated by the <code>SmbResource</code> argument.
      * <br>
-     * <i>Remember: <code>SmbResource</code>s are immutible and therefore
+     * <i>Remember: <code>SmbResource</code>s are immutable and therefore
      * the path associated with this <code>SmbResource</code> object will not
      * change). To access the renamed file it is necessary to construct a
      * new <tt>SmbResource</tt></i>.
@@ -671,7 +671,7 @@ public interface SmbResource extends AutoCloseable {
     /**
      * Fetch all children
      * 
-     * @return an interator over the child resources
+     * @return an iterator over the child resources
      * @throws CIFSException
      */
     CloseableIterator<SmbResource> children () throws CIFSException;
@@ -691,7 +691,7 @@ public interface SmbResource extends AutoCloseable {
      * Wildcard expressions will not filter workgroup names or server names.
      * 
      * @param wildcard
-     * @return an interator over the child resources
+     * @return an iterator over the child resources
      * @throws CIFSException
      */
     CloseableIterator<SmbResource> children ( String wildcard ) throws CIFSException;
@@ -700,7 +700,7 @@ public interface SmbResource extends AutoCloseable {
     /**
      * @param filter
      *            filter acting on file names
-     * @return an interator over the child resources
+     * @return an iterator over the child resources
      * @see SmbResource#children(String) for a more efficient way to do this when a pattern on the filename is
      *      sufficient for filtering
      * @throws CIFSException
@@ -711,7 +711,7 @@ public interface SmbResource extends AutoCloseable {
     /**
      * @param filter
      *            filter acting on SmbResource instances
-     * @return an interator over the child resources
+     * @return an iterator over the child resources
      * @see SmbResource#children(String) for a more efficient way to do this when a pattern on the filename is
      *      sufficient for filtering
      * @throws CIFSException

--- a/src/main/java/jcifs/SmbResourceLocator.java
+++ b/src/main/java/jcifs/SmbResourceLocator.java
@@ -56,12 +56,12 @@ public interface SmbResourceLocator {
 
     /**
      * Everything but the last component of the URL representing this SMB
-     * resource is effectivly it's parent. The root URL <code>smb://</code>
+     * resource is effectively it's parent. The root URL <code>smb://</code>
      * does not have a parent. In this case <code>smb://</code> is returned.
      *
      * @return The parent directory of this SMB resource or
      *         <code>smb://</code> if the resource refers to the root of the URL
-     *         hierarchy which incedentally is also <code>smb://</code>.
+     *         hierarchy which incidentally is also <code>smb://</code>.
      */
     String getParent ();
 

--- a/src/main/java/jcifs/config/BaseConfiguration.java
+++ b/src/main/java/jcifs/config/BaseConfiguration.java
@@ -214,8 +214,15 @@ public class BaseConfiguration implements Configuration {
     }
 
 
+    @Deprecated
     @Override
     public int getRecieveBufferSize () {
+        return this.smbRecvBufferSize;
+    }
+
+
+    @Override
+    public int getReceiveBufferSize () {
         return this.smbRecvBufferSize;
     }
 

--- a/src/main/java/jcifs/config/DelegatingConfiguration.java
+++ b/src/main/java/jcifs/config/DelegatingConfiguration.java
@@ -39,7 +39,7 @@ public class DelegatingConfiguration implements Configuration {
 
     /**
      * @param delegate
-     *            delegate to pass all non-overriden method calls to
+     *            delegate to pass all non-overridden method calls to
      * 
      */
     public DelegatingConfiguration ( Configuration delegate ) {

--- a/src/main/java/jcifs/config/DelegatingConfiguration.java
+++ b/src/main/java/jcifs/config/DelegatingConfiguration.java
@@ -226,11 +226,23 @@ public class DelegatingConfiguration implements Configuration {
     /**
      * {@inheritDoc}
      * 
-     * @see jcifs.Configuration#getRecieveBufferSize()
+     * @deprecated use getReceiveBufferSize instead
      */
+    @Deprecated
     @Override
     public int getRecieveBufferSize () {
-        return this.delegate.getRecieveBufferSize();
+        return this.delegate.getReceiveBufferSize();
+    }
+
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see jcifs.Configuration#getReceiveBufferSize()
+     */
+    @Override
+    public int getReceiveBufferSize () {
+        return this.delegate.getReceiveBufferSize();
     }
 
 

--- a/src/main/java/jcifs/context/SingletonContext.java
+++ b/src/main/java/jcifs/context/SingletonContext.java
@@ -121,7 +121,7 @@ public class SingletonContext extends BaseContext implements CIFSContext {
     public static void registerSmbURLHandler () {
         String pkgs;
         float ver = Float.parseFloat(Runtime.class.getPackage().getSpecificationVersion());
-	if ( !"http://www.android.com".equalsIgnoreCase(System.getProperty("java.vendor.url")) && ver < 1.7f) {
+        if ( !"http://www.android.com".equalsIgnoreCase(System.getProperty("java.vendor.url")) && ver < 1.7f) {
             throw new RuntimeCIFSException("jcifs-ng requires Java 1.7 or above. You are running " + ver);
         }
 

--- a/src/main/java/jcifs/http/NtlmHttpFilter.java
+++ b/src/main/java/jcifs/http/NtlmHttpFilter.java
@@ -102,7 +102,7 @@ public class NtlmHttpFilter implements Filter {
         p.setProperty("jcifs.netbios.cachePolicy", "1200");
         /*
          * The Filter can only work with NTLMv1 as it uses a man-in-the-middle
-         * techinque that NTLMv2 specifically thwarts. A real NTLM Filter would
+         * technique that NTLMv2 specifically thwarts. A real NTLM Filter would
          * need to do a NETLOGON RPC that JCIFS will likely never implement
          * because it requires a lot of extra crypto not used by CIFS.
          */

--- a/src/main/java/jcifs/http/NtlmServlet.java
+++ b/src/main/java/jcifs/http/NtlmServlet.java
@@ -47,7 +47,7 @@ import jcifs.smb.SmbAuthException;
 /**
  * This servlet may be used with pre-2.3 servlet containers
  * to protect content with NTLM HTTP Authentication. Servlets that
- * extend this abstract base class may be authenticatied against an SMB
+ * extend this abstract base class may be authenticated against an SMB
  * server or domain controller depending on how the
  * <tt>jcifs.smb.client.domain</tt> or <tt>jcifs.http.domainController</tt>
  * properties are be specified. <b>With later containers the

--- a/src/main/java/jcifs/http/NtlmSsp.java
+++ b/src/main/java/jcifs/http/NtlmSsp.java
@@ -39,7 +39,7 @@ import jcifs.smb.NtlmPasswordAuthentication;
 
 /**
  * This class is used internally by <tt>NtlmHttpFilter</tt>,
- * <tt>NtlmServlet</tt>, and <tt>NetworkExplorer</tt> to negiotiate password
+ * <tt>NtlmServlet</tt>, and <tt>NetworkExplorer</tt> to negotiate password
  * hashes via NTLM SSP with MSIE. It might also be used directly by servlet
  * containers to incorporate similar functionality.
  * <p>

--- a/src/main/java/jcifs/internal/SMBSigningDigest.java
+++ b/src/main/java/jcifs/internal/SMBSigningDigest.java
@@ -26,7 +26,7 @@ public interface SMBSigningDigest {
 
     /**
      * Performs MAC signing of the SMB. This is done as follows.
-     * The signature field of the SMB is overwritted with the sequence number;
+     * The signature field of the SMB is overwritten with the sequence number;
      * The MD5 digest of the MAC signing key + the entire SMB is taken;
      * The first 8 bytes of this are placed in the signature field.
      *

--- a/src/main/java/jcifs/internal/SmbNegotiationResponse.java
+++ b/src/main/java/jcifs/internal/SmbNegotiationResponse.java
@@ -112,7 +112,7 @@ public interface SmbNegotiationResponse extends CommonServerMessageBlock, Respon
 
     /**
      * 
-     * @return numer of initial credits the server grants
+     * @return number of initial credits the server grants
      */
     int getInitialCredits ();
 

--- a/src/main/java/jcifs/internal/smb1/com/SmbComNegotiateResponse.java
+++ b/src/main/java/jcifs/internal/smb1/com/SmbComNegotiateResponse.java
@@ -71,7 +71,7 @@ public class SmbComNegotiateResponse extends ServerMessageBlock implements SmbNe
         this.negotiatedFlags2 = ctx.getConfig().getFlags2();
         this.maxMpxCount = ctx.getConfig().getMaxMpxCount();
         this.snd_buf_size = ctx.getConfig().getSendBufferSize();
-        this.recv_buf_size = ctx.getConfig().getRecieveBufferSize();
+        this.recv_buf_size = ctx.getConfig().getReceiveBufferSize();
         this.tx_buf_size = ctx.getConfig().getTransactionBufferSize();
         this.useUnicode = ctx.getConfig().isUseUnicode();
     }

--- a/src/main/java/jcifs/internal/smb2/ServerMessageBlock2.java
+++ b/src/main/java/jcifs/internal/smb2/ServerMessageBlock2.java
@@ -37,7 +37,7 @@ public abstract class ServerMessageBlock2 implements CommonServerMessageBlock {
 
     /*
      * These are all the smbs supported by this library. This includes requests
-     * and well as their responses for each type however the actuall implementations
+     * and well as their responses for each type however the actual implementations
      * of the readXxxWireFormat and writeXxxWireFormat methods may not be in
      * place. For example at the time of this writing the readXxxWireFormat
      * for requests and the writeXxxWireFormat for responses are not implemented

--- a/src/main/java/jcifs/internal/smb2/nego/Smb2NegotiateResponse.java
+++ b/src/main/java/jcifs/internal/smb2/nego/Smb2NegotiateResponse.java
@@ -294,7 +294,7 @@ public class Smb2NegotiateResponse extends ServerMessageBlock2Response implement
         }
 
         int maxBufferSize = tc.getConfig().getTransactionBufferSize();
-        this.maxReadSize = Math.min(maxBufferSize - Smb2ReadResponse.OVERHEAD, Math.min(tc.getConfig().getRecieveBufferSize(), this.maxReadSize))
+        this.maxReadSize = Math.min(maxBufferSize - Smb2ReadResponse.OVERHEAD, Math.min(tc.getConfig().getReceiveBufferSize(), this.maxReadSize))
                 & ~0x7;
         this.maxWriteSize = Math.min(maxBufferSize - Smb2WriteRequest.OVERHEAD, Math.min(tc.getConfig().getSendBufferSize(), this.maxWriteSize))
                 & ~0x7;

--- a/src/main/java/jcifs/smb/DfsImpl.java
+++ b/src/main/java/jcifs/smb/DfsImpl.java
@@ -821,7 +821,7 @@ public class DfsImpl implements DfsResolver {
 
         /*
          * Subtract the server and share from the pathConsumed so that
-         * it refects the part of the relative path consumed and not
+         * it reflects the part of the relative path consumed and not
          * the entire path.
          */
         dri.stripPathConsumed(1 + server.length() + 1 + share.length());

--- a/src/main/java/jcifs/smb/DosFileFilter.java
+++ b/src/main/java/jcifs/smb/DosFileFilter.java
@@ -31,7 +31,7 @@ public class DosFileFilter implements SmbFileFilter {
 
     /**
      * This filter can be considerably more efficient than other file filters
-     * as the specifed wildcard and attributes are passed to the server for
+     * as the specified wildcard and attributes are passed to the server for
      * filtering there (although attributes are largely ignored by servers
      * they are filtered locally by the default accept method).
      * 

--- a/src/main/java/jcifs/smb/Kerb5Authenticator.java
+++ b/src/main/java/jcifs/smb/Kerb5Authenticator.java
@@ -75,7 +75,7 @@ public class Kerb5Authenticator extends NtlmPasswordAuthentication {
 
 
     /**
-     * Contruct a <code>Kerb5Authenticator</code> object with <code>Subject</code>
+     * Construct a <code>Kerb5Authenticator</code> object with <code>Subject</code>
      * which hold TGT retrieved from KDC. If multiple TGT are contained, the
      * first one will be used to retrieve user principal.
      * 
@@ -92,7 +92,7 @@ public class Kerb5Authenticator extends NtlmPasswordAuthentication {
 
 
     /**
-     * Contruct a <code>Kerb5Authenticator</code> object with <code>Subject</code> and
+     * Construct a <code>Kerb5Authenticator</code> object with <code>Subject</code> and
      * potential NTLM fallback (if the server does not support kerberos).
      * 
      * @param tc
@@ -134,7 +134,7 @@ public class Kerb5Authenticator extends NtlmPasswordAuthentication {
     @Override
     public SSPContext createContext ( CIFSContext tc, String targetDomain, String host, byte[] initialToken, boolean doSigning ) throws SmbException {
         if ( host.indexOf('.') < 0 && host.toUpperCase(Locale.ROOT).equals(host) ) {
-            // this is not too good, propably should better pass the address and check that it is a netbios one.
+            // this is not too good, probably should better pass the address and check that it is a netbios one.
             // While we could look up the domain controller/KDC we cannot really make the java kerberos implementation
             // use a KDC of our choice.
             // A potential workaround would be to try to get the server FQDN by reverse lookup, but this might have

--- a/src/main/java/jcifs/smb/Kerb5Context.java
+++ b/src/main/java/jcifs/smb/Kerb5Context.java
@@ -267,7 +267,7 @@ class Kerb5Context implements SSPContext {
         /*
          * The kerberos session key is not accessible via the JGSS API. IBM and
          * Oracle both implement a similar API to make an ExtendedGSSContext
-         * available. That API is accessed via reflection to make this independend
+         * available. That API is accessed via reflection to make this independent
          * of the runtime JRE
          */
         if ( EXT_GSS_CONTEXT_CLASS == null || INQUIRE_SEC_CONTEXT == null || INQUIRE_TYPE_SESSION_KEY == null ) {
@@ -353,7 +353,7 @@ class Kerb5Context implements SSPContext {
 
     /*
      * Prepare reflective access to ExtendedGSSContext. The reflective access
-     * abstracts the acces so far, that Oracle JDK, Open JDK and IBM JDK are
+     * abstracts the access so far, that Oracle JDK, Open JDK and IBM JDK are
      * supported.
      * 
      * At the time of the first implementation only a test on Oracle JDK was

--- a/src/main/java/jcifs/smb/NtStatus.java
+++ b/src/main/java/jcifs/smb/NtStatus.java
@@ -23,7 +23,7 @@ package jcifs.smb;
 public interface NtStatus {
 
     /*
-     * Don't bother to edit this. Everthing within the interface
+     * Don't bother to edit this. Everything within the interface
      * block is automatically generated from the ntstatus package.
      */
 

--- a/src/main/java/jcifs/smb/NtlmPasswordAuthentication.java
+++ b/src/main/java/jcifs/smb/NtlmPasswordAuthentication.java
@@ -531,7 +531,7 @@ public class NtlmPasswordAuthentication implements Principal, CredentialsInterna
      * their caseless domain and username fields are equal and either both hashes are external and they are equal or
      * both internally supplied passwords are equal. If one <tt>NtlmPasswordAuthentication</tt> object has external
      * hashes (meaning negotiated via NTLM HTTP Authentication) and the other does not they will not be equal. This is
-     * technically not correct however the server 8 byte challage would be required to compute and compare the password
+     * technically not correct however the server 8 byte challenge would be required to compute and compare the password
      * hashes but that it not available with this method.
      */
     @Override
@@ -615,7 +615,7 @@ public class NtlmPasswordAuthentication implements Principal, CredentialsInterna
                 break;
             case 1:
                 /*
-                 * Get ASCII hex value and convert to platform dependant
+                 * Get ASCII hex value and convert to platform dependent
                  * encoding like EBCDIC perhaps
                  */
                 b[ 0 ] = (byte) ( Integer.parseInt(str.substring(i, i + 2), 16) & 0xFF );

--- a/src/main/java/jcifs/smb/NtlmUtil.java
+++ b/src/main/java/jcifs/smb/NtlmUtil.java
@@ -115,7 +115,7 @@ public final class NtlmUtil {
     /**
      * 
      * @param password
-     * @return the calulated hash
+     * @return the calculated hash
      */
     public static byte[] nTOWFv1 ( String password ) {
         if ( password == null )

--- a/src/main/java/jcifs/smb/SmbException.java
+++ b/src/main/java/jcifs/smb/SmbException.java
@@ -33,8 +33,8 @@ import jcifs.util.Hexdump;
  * are provided.
  * <p>
  * The jCIFS client maps DOS error codes to NTSTATUS codes. This means that
- * the user may recieve a different error from a legacy server than that of
- * a newer varient such as Windows NT and above. If you should encounter
+ * the user may receive a different error from a legacy server than that of
+ * a newer variant such as Windows NT and above. If you should encounter
  * such a case, please report it to jcifs at samba dot org and we will
  * change the mapping.
  */

--- a/src/main/java/jcifs/smb/SmbFile.java
+++ b/src/main/java/jcifs/smb/SmbFile.java
@@ -176,7 +176,7 @@ import jcifs.internal.smb2.info.Smb2SetInfoRequest;
  * <td width="20%">
  * <code>smb://Administrator:P%40ss@msmith1/c/WINDOWS/Desktop/foo.txt</code></td>
  * <td>
- * A relativly sophisticated example that references a file
+ * A relatively sophisticated example that references a file
  * <code>msmith1</code>'s desktop as user <code>Administrator</code>. Notice the '@' is URL encoded with the '%40'
  * hexcode escape.
  * </td>
@@ -234,7 +234,7 @@ import jcifs.internal.smb2.info.Smb2SetInfoRequest;
  * a common base. This is slightly different from the corresponding
  * <code>java.io.File</code> usage; a '/' at the beginning of the second
  * parameter will still use the server component of the first parameter. The
- * examples below illustrate the resulting URLs when this second contructor
+ * examples below illustrate the resulting URLs when this second constructor
  * argument is used.
  *
  * <p>
@@ -407,7 +407,7 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
      * @param context
      *            A base <code>SmbFile</code>
      * @param name
-     *            A path string relative to the <code>parent</code> paremeter
+     *            A path string relative to the <code>parent</code> parameter
      * @throws MalformedURLException
      *             If the <code>parent</code> and <code>child</code> parameters
      *             do not follow the prescribed syntax
@@ -887,12 +887,12 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
 
     /**
      * Everything but the last component of the URL representing this SMB
-     * resource is effectivly it's parent. The root URL <code>smb://</code>
+     * resource is effectively it's parent. The root URL <code>smb://</code>
      * does not have a parent. In this case <code>smb://</code> is returned.
      *
      * @return The parent directory of this SMB resource or
      *         <code>smb://</code> if the resource refers to the root of the URL
-     *         hierarchy which incedentally is also <code>smb://</code>.
+     *         hierarchy which incidentally is also <code>smb://</code>.
      */
     public String getParent () {
         return this.fileLocator.getParent();
@@ -913,7 +913,7 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
 
 
     /**
-     * Retuns the Windows UNC style path with backslashs intead of forward slashes.
+     * Returns the Windows UNC style path with backslashes instead of forward slashes.
      *
      * @return The UNC path.
      */
@@ -1510,7 +1510,7 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
                 catch ( SmbException se ) {
                     /*
                      * Oracle FilesOnline version 9.0.4 doesn't send '.' and '..' so
-                     * listFiles may generate undesireable "cannot find
+                     * listFiles may generate undesirable "cannot find
                      * the file specified".
                      */
                     log.debug("delete", se);
@@ -1703,7 +1703,7 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
             catch ( SmbException e ) {
                 log.debug("mkdirs", e);
                 // Ignore "Cannot create a file when that file already exists." errors for now as
-                // they seem to be show up under some cinditions most likely due to timing issues.
+                // they seem to be show up under some conditions most likely due to timing issues.
                 if ( e.getNtStatus() != NtStatus.NT_STATUS_OBJECT_NAME_COLLISION ) {
                     throw e;
                 }
@@ -1967,7 +1967,7 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
      * Computes a hashCode for this file based on the URL string and IP
      * address if the server. The hashing function uses the hashcode of the
      * server address, the canonical representation of the URL, and does not
-     * compare authentication information. In essance, two
+     * compare authentication information. In essence, two
      * <code>SmbFile</code> objects that refer to
      * the same file should generate the same hashcode provided it is possible
      * to make such a determination.
@@ -1986,7 +1986,7 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
      * resource. More specifically, two <code>SmbFile</code> objects are
      * equals if their server IP addresses are equal and the canonicalized
      * representation of their URLs, minus authentication parameters, are
-     * case insensitivly and lexographically equal.
+     * case insensitively and lexographically equal.
      * <br>
      * For example, assuming the server <code>angus</code> resolves to the
      * <code>192.168.1.15</code> IP address, the below URLs would result in

--- a/src/main/java/jcifs/smb/SmbFileInputStream.java
+++ b/src/main/java/jcifs/smb/SmbFileInputStream.java
@@ -142,7 +142,7 @@ public class SmbFileInputStream extends InputStream {
 
         if ( th.hasCapability(SmbConstants.CAP_LARGE_READX) ) {
             this.largeReadX = true;
-            this.readSizeFile = Math.min(th.getConfig().getRecieveBufferSize() - 70, th.areSignaturesActive() ? 0xFFFF - 70 : 0xFFFFFF - 70);
+            this.readSizeFile = Math.min(th.getConfig().getReceiveBufferSize() - 70, th.areSignaturesActive() ? 0xFFFF - 70 : 0xFFFFFF - 70);
             log.debug("Enabling LARGE_READX with " + this.readSizeFile);
         }
         else {

--- a/src/main/java/jcifs/smb/SmbRandomAccessFile.java
+++ b/src/main/java/jcifs/smb/SmbRandomAccessFile.java
@@ -132,7 +132,7 @@ public class SmbRandomAccessFile implements SmbRandomAccess {
 
             if ( th.hasCapability(SmbConstants.CAP_LARGE_READX) ) {
                 this.largeReadX = true;
-                this.readSize = Math.min(th.getConfig().getRecieveBufferSize() - 70, th.areSignaturesActive() ? 0xFFFF - 70 : 0xFFFFFF - 70);
+                this.readSize = Math.min(th.getConfig().getReceiveBufferSize() - 70, th.areSignaturesActive() ? 0xFFFF - 70 : 0xFFFFFF - 70);
             }
 
             // there seems to be a bug with some servers that causes corruption if using signatures + CAP_LARGE_WRITE

--- a/src/main/java/jcifs/smb/SmbSessionImpl.java
+++ b/src/main/java/jcifs/smb/SmbSessionImpl.java
@@ -1022,7 +1022,7 @@ final class SmbSessionImpl implements SmbSessionInternal {
                     catch ( SmbException se ) {
                         ex = se;
                         /*
-                         * Apparently once a successfull NTLMSSP login occurs, the
+                         * Apparently once a successful NTLMSSP login occurs, the
                          * server will return "Access denied" even if a logoff is
                          * sent. Unfortunately calling disconnect() doesn't always
                          * actually shutdown the connection before other threads

--- a/src/main/java/jcifs/smb/SmbTransportImpl.java
+++ b/src/main/java/jcifs/smb/SmbTransportImpl.java
@@ -1273,7 +1273,7 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
     protected void doSkip ( Long key ) throws IOException {
         synchronized ( this.inLock ) {
             int size = Encdec.dec_uint16be(this.sbuf, 2) & 0xFFFF;
-            if ( size < 33 || ( 4 + size ) > this.getContext().getConfig().getRecieveBufferSize() ) {
+            if ( size < 33 || ( 4 + size ) > this.getContext().getConfig().getReceiveBufferSize() ) {
                 /* log message? */
                 log.warn("Flusing stream input");
                 this.in.skip(this.in.available());

--- a/src/main/java/jcifs/smb/SmbTransportImpl.java
+++ b/src/main/java/jcifs/smb/SmbTransportImpl.java
@@ -469,7 +469,7 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
         /*
          * We cannot use Transport.sendrecv() yet because
          * the Transport thread is not setup until doConnect()
-         * returns and we want to supress all communication
+         * returns and we want to suppress all communication
          * until we have properly negotiated.
          */
         synchronized ( this.inLock ) {

--- a/src/main/java/jcifs/smb/SmbTreeImpl.java
+++ b/src/main/java/jcifs/smb/SmbTreeImpl.java
@@ -382,7 +382,7 @@ class SmbTreeImpl implements SmbTreeInternal {
 
 
     /**
-     * @return the tree_num (monotoincally increasing counter to track reconnects)
+     * @return the tree_num (monotonically increasing counter to track reconnects)
      */
     public long getTreeNum () {
         return this.treeNum;
@@ -433,7 +433,7 @@ class SmbTreeImpl implements SmbTreeInternal {
             }
 
             // fall trough if the tree connection is already established
-            // and send it as a separate request instread
+            // and send it as a separate request instead
             String svc = null;
             int t = this.tid;
             if ( t == 0 ) {

--- a/src/main/java/jcifs/smb/WinError.java
+++ b/src/main/java/jcifs/smb/WinError.java
@@ -23,7 +23,7 @@ package jcifs.smb;
 public interface WinError {
 
     /*
-     * Don't bother to edit this. Everthing within the interface
+     * Don't bother to edit this. Everything within the interface
      * block is automatically generated from the ntstatus package.
      */
 


### PR DESCRIPTION
Applying the boy-scout rule while browsing the code, I fixed some typos in the code (first commit).

In the second commit, I approached a public method Config#getRecieveBufferSize which should be Config#getReceiveBufferSize.

I deprecated the old method and created a new one. This is of course more sensible than just fixing the typos in the comments, as it will have an effect for the users of the library.