### PR TITLE
fix SmbFIle.getDfsPath() to not return "null/" if not DFS but is dir

### DIFF
--- a/src/main/java/jcifs/smb/SmbFile.java
+++ b/src/main/java/jcifs/smb/SmbFile.java
@@ -940,7 +940,7 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
     public String getDfsPath () throws SmbException {
         try {
             String path = this.treeConnection.ensureDFSResolved(this.fileLocator).getDfsPath();
-            if ( isDirectory() ) {
+            if ( path != null && isDirectory() ) {
                 path += '/';
             }
             return path;


### PR DESCRIPTION
What I'm seeing is that calls to getDfsPath() when not using DFS are returning the string "null/" instead of null when the SmbFile represents a directory. This appears to be a problem in both 2.0.6 and 2.1