### PR TITLE
Fix SMB2 NamedPipe implementation

### DIFF
--- a/src/main/java/jcifs/internal/smb2/io/Smb2ReadResponse.java
+++ b/src/main/java/jcifs/internal/smb2/io/Smb2ReadResponse.java
@@ -23,6 +23,7 @@ import jcifs.internal.SMBProtocolDecodingException;
 import jcifs.internal.smb2.ServerMessageBlock2Response;
 import jcifs.internal.smb2.Smb2Constants;
 import jcifs.internal.util.SMBUtil;
+import jcifs.smb.NtStatus;
 
 
 /**
@@ -114,5 +115,16 @@ public class Smb2ReadResponse extends ServerMessageBlock2Response {
         bufferIndex = Math.max(bufferIndex, dataStart + this.dataLength);
         return bufferIndex - start;
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see jcifs.internal.smb2.ServerMessageBlock2#isErrorResponseStatus()
+     */
+    @Override
+    protected boolean isErrorResponseStatus () {
+        return getStatus() != NtStatus.NT_STATUS_BUFFER_OVERFLOW && super.isErrorResponseStatus();
+    }
+
 
 }

--- a/src/main/java/jcifs/internal/smb2/ioctl/Smb2IoctlRequest.java
+++ b/src/main/java/jcifs/internal/smb2/ioctl/Smb2IoctlRequest.java
@@ -162,7 +162,7 @@ public class Smb2IoctlRequest extends ServerMessageBlock2Request<Smb2IoctlRespon
 
     @Override
     protected Smb2IoctlResponse createResponse ( CIFSContext tc, ServerMessageBlock2Request<Smb2IoctlResponse> req ) {
-        return new Smb2IoctlResponse(tc.getConfig(), this.outputBuffer);
+        return new Smb2IoctlResponse(tc.getConfig(), this.outputBuffer, this.controlCode);
     }
 
 

--- a/src/main/java/jcifs/internal/smb2/ioctl/Smb2IoctlResponse.java
+++ b/src/main/java/jcifs/internal/smb2/ioctl/Smb2IoctlResponse.java
@@ -46,7 +46,7 @@ public class Smb2IoctlResponse extends ServerMessageBlock2Response {
     /**
      * @param config
      */
-    public Smb2IoctlResponse ( Configuration config ) {
+    public Smb2IoctlResponse ( Configuration config) {
         super(config);
         this.outputBuffer = null;
     }
@@ -61,7 +61,17 @@ public class Smb2IoctlResponse extends ServerMessageBlock2Response {
         this.outputBuffer = outputBuffer;
     }
 
-
+    /**
+     * @param config
+     * @param outputBuffer
+     * @param ctlCode
+     */
+    public Smb2IoctlResponse ( Configuration config, byte[] outputBuffer,  int ctlCode ) {
+        super(config);
+        this.outputBuffer = outputBuffer;
+        this.ctlCode = ctlCode;
+    }
+    
     /**
      * @return the ctlCode
      */
@@ -128,7 +138,16 @@ public class Smb2IoctlResponse extends ServerMessageBlock2Response {
      */
     @Override
     protected boolean isErrorResponseStatus () {
-        return getStatus() != NtStatus.NT_STATUS_INVALID_PARAMETER && super.isErrorResponseStatus();
+        int status = getStatus();
+        return status != NtStatus.NT_STATUS_INVALID_PARAMETER &&
+                !( status == NtStatus.NT_STATUS_INVALID_PARAMETER &&
+                        ( ctlCode == Smb2IoctlRequest.FSCTL_SRV_COPYCHUNK ||
+                                ctlCode == Smb2IoctlRequest.FSCTL_SRV_COPYCHUNK_WRITE ) ) && 
+                !( status == NtStatus.NT_STATUS_BUFFER_OVERFLOW &&
+                        ( ctlCode == Smb2IoctlRequest.FSCTL_PIPE_TRANSCEIVE ||
+                                ctlCode == Smb2IoctlRequest.FSCTL_PIPE_PEEK ||
+                                ctlCode == Smb2IoctlRequest.FSCTL_DFS_GET_REFERRALS ) ) &&         
+                super.isErrorResponseStatus();
     }
 
 
@@ -208,6 +227,8 @@ public class Smb2IoctlResponse extends ServerMessageBlock2Response {
             return new SrvCopyChunkCopyResponse();
         case Smb2IoctlRequest.FSCTL_VALIDATE_NEGOTIATE_INFO:
             return new ValidateNegotiateInfoResponse();
+        case Smb2IoctlRequest.FSCTL_PIPE_PEEK:
+            return new SrvPipePeekResponse();
         }
         return null;
     }

--- a/src/main/java/jcifs/internal/smb2/ioctl/SrvPipePeekResponse.java
+++ b/src/main/java/jcifs/internal/smb2/ioctl/SrvPipePeekResponse.java
@@ -1,0 +1,101 @@
+/*
+ * © 2017 AgNO3 Gmbh & Co. KG
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package jcifs.internal.smb2.ioctl;
+
+
+import jcifs.Decodable;
+import jcifs.internal.SMBProtocolDecodingException;
+import jcifs.internal.util.SMBUtil;
+
+
+/**
+ * @author svella
+ *
+ */
+public class SrvPipePeekResponse implements Decodable {
+
+    // see https://msdn.microsoft.com/en-us/library/dd414577.aspx
+    
+    private int namedPipeState;
+    private int readDataAvailable;
+    private int numberOfMessages;
+    private int messageLength;
+    private byte [] data; 
+
+
+    /**
+     * @return the chunkBytesWritten
+     */
+    public int getNamedPipeState () {
+        return this.namedPipeState;
+    }
+
+
+    /**
+     * @return the chunksWritten
+     */
+    public int getReadDataAvailable () {
+        return this.readDataAvailable;
+    }
+
+
+    /**
+     * @return the totalBytesWritten
+     */
+    public int getNumberOfMessages () {
+        return this.numberOfMessages;
+    }
+
+    /**
+     * @return the totalBytesWritten
+     */
+    public int getMessageLength () {
+        return this.messageLength;
+    }
+
+    /**
+     * @return the totalBytesWritten
+     */
+    public byte [] getData () {
+        return this.data;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see Decodable#decode(byte[], int, int)
+     */
+    @Override
+    public int decode ( byte[] buffer, int bufferIndex, int len ) throws SMBProtocolDecodingException {
+        int start = bufferIndex;
+        this.namedPipeState = SMBUtil.readInt4(buffer, bufferIndex);
+        bufferIndex += 4;
+        this.readDataAvailable = SMBUtil.readInt4(buffer, bufferIndex);
+        bufferIndex += 4;
+        this.numberOfMessages = SMBUtil.readInt4(buffer, bufferIndex);
+        bufferIndex += 4;
+        this.messageLength = SMBUtil.readInt4(buffer, bufferIndex);
+        bufferIndex += 4;
+        data = new byte[len - 16];
+        if (data.length > 0) {
+            System.arraycopy(buffer, bufferIndex, data, 0, data.length);
+        }
+        return 0;
+    }
+
+}

--- a/src/main/java/jcifs/internal/smb2/notify/Smb2ChangeNotifyResponse.java
+++ b/src/main/java/jcifs/internal/smb2/notify/Smb2ChangeNotifyResponse.java
@@ -28,6 +28,7 @@ import jcifs.internal.SMBProtocolDecodingException;
 import jcifs.internal.smb1.trans.nt.FileNotifyInformationImpl;
 import jcifs.internal.smb2.ServerMessageBlock2Response;
 import jcifs.internal.util.SMBUtil;
+import jcifs.smb.NtStatus;
 
 
 /**
@@ -106,5 +107,16 @@ public class Smb2ChangeNotifyResponse extends ServerMessageBlock2Response implem
     public List<FileNotifyInformation> getNotifyInformation () {
         return this.notifyInformation;
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see jcifs.internal.smb2.ServerMessageBlock2#isErrorResponseStatus()
+     */
+    @Override
+    protected boolean isErrorResponseStatus () {
+        return getStatus() != NtStatus.NT_STATUS_NOTIFY_ENUM_DIR && super.isErrorResponseStatus();
+    }
+
 
 }

--- a/src/main/java/jcifs/smb/NtStatus.java
+++ b/src/main/java/jcifs/smb/NtStatus.java
@@ -29,6 +29,8 @@ public interface NtStatus {
 
     public static final int NT_STATUS_OK = 0x00000000;
     public static final int NT_STATUS_PENDING = 0x00000103;
+    public static final int NT_STATUS_NOTIFY_ENUM_DIR = 0x0000010C;
+    public static final int NT_STATUS_BUFFER_OVERFLOW = 0x80000005;
     public static final int NT_STATUS_UNSUCCESSFUL = 0xC0000001;
     public static final int NT_STATUS_NOT_IMPLEMENTED = 0xC0000002;
     public static final int NT_STATUS_INVALID_INFO_CLASS = 0xC0000003;
@@ -96,7 +98,8 @@ public interface NtStatus {
     public static final int NT_STATUS_IO_REPARSE_TAG_NOT_HANDLED = 0xC0000279;
 
     static final int[] NT_STATUS_CODES = {
-        NT_STATUS_OK, NT_STATUS_PENDING, NT_STATUS_UNSUCCESSFUL, NT_STATUS_NOT_IMPLEMENTED, NT_STATUS_INVALID_INFO_CLASS, NT_STATUS_ACCESS_VIOLATION,
+        NT_STATUS_OK, NT_STATUS_PENDING, NT_STATUS_NOTIFY_ENUM_DIR, NT_STATUS_BUFFER_OVERFLOW, NT_STATUS_UNSUCCESSFUL,
+        NT_STATUS_NOT_IMPLEMENTED, NT_STATUS_INVALID_INFO_CLASS, NT_STATUS_ACCESS_VIOLATION,
         NT_STATUS_INVALID_HANDLE, NT_STATUS_INVALID_PARAMETER, NT_STATUS_NO_SUCH_DEVICE, NT_STATUS_NO_SUCH_FILE, NT_STATUS_MORE_PROCESSING_REQUIRED,
         NT_STATUS_ACCESS_DENIED, NT_STATUS_BUFFER_TOO_SMALL, NT_STATUS_OBJECT_NAME_INVALID, NT_STATUS_OBJECT_NAME_NOT_FOUND,
         NT_STATUS_OBJECT_NAME_COLLISION, NT_STATUS_PORT_DISCONNECTED, NT_STATUS_OBJECT_PATH_INVALID, NT_STATUS_OBJECT_PATH_NOT_FOUND,
@@ -111,10 +114,12 @@ public interface NtStatus {
         NT_STATUS_NO_TRUST_SAM_ACCOUNT, NT_STATUS_TRUSTED_DOMAIN_FAILURE, NT_STATUS_TRUSTED_RELATIONSHIP_FAILURE,
         NT_STATUS_NOLOGON_WORKSTATION_TRUST_ACCOUNT, NT_STATUS_PASSWORD_MUST_CHANGE, NT_STATUS_NOT_FOUND, NT_STATUS_ACCOUNT_LOCKED_OUT,
         NT_STATUS_CONNECTION_REFUSED, NT_STATUS_PATH_NOT_COVERED, NT_STATUS_IO_REPARSE_TAG_NOT_HANDLED,
+        NT_STATUS_PENDING, NT_STATUS_NOTIFY_ENUM_DIR
     };
 
     static final String[] NT_STATUS_MESSAGES = {
-        "The operation completed successfully.", "Request is pending", "A device attached to the system is not functioning.", "Incorrect function.",
+        "The operation completed successfully.", "Request is pending", "A notify change request is being completed.", 
+        "The data was too large to fit into the specified buffer.", "A device attached to the system is not functioning.", "Incorrect function.", 
         "The parameter is incorrect.", "Invalid access to memory location.", "The handle is invalid.", "The parameter is incorrect.",
         "The system cannot find the file specified.", "The system cannot find the file specified.", "More data is available.", "Access is denied.",
         "The data area passed to a system call is too small.", "The filename, directory name, or volume label syntax is incorrect.",

--- a/src/main/java/jcifs/smb/SmbException.java
+++ b/src/main/java/jcifs/smb/SmbException.java
@@ -19,7 +19,9 @@
 package jcifs.smb;
 
 
-import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import jcifs.CIFSException;
 import jcifs.util.Hexdump;
@@ -45,6 +47,42 @@ public class SmbException extends CIFSException implements NtStatus, DosError, W
      * 
      */
     private static final long serialVersionUID = 484863569441792249L;
+    
+    // to replace a bunch of one-off binary searches
+    private static final Map<Integer, String> errorCodeMessages;
+    private static final Map<Integer, String> winErrorCodeMessages;
+    private static final Map<Integer, Integer> dosErrorCodeStatuses;
+
+    static {
+        Map<Integer, String> errorCodeMessagesTmp = new HashMap<>();
+        for (int i = 0; i < NtStatus.NT_STATUS_CODES.length; i++) {
+            errorCodeMessagesTmp.put(NtStatus.NT_STATUS_CODES[i], NtStatus.NT_STATUS_MESSAGES[i]);
+        }
+
+        Map<Integer, Integer> dosErrorCodeStatusesTmp = new HashMap<>();
+        for (int i = 0; i < DosError.DOS_ERROR_CODES.length; i++) {
+            errorCodeMessagesTmp.put(DosError.DOS_ERROR_CODES[i][0], DosError.DOS_ERROR_MESSAGES[i]);
+            dosErrorCodeStatusesTmp.put(DosError.DOS_ERROR_CODES[i][0], DosError.DOS_ERROR_CODES[i][1]);
+        }
+        
+        // for backward compatibility since this is was different message in the NtStatus.NT_STATUS_CODES than returned
+        // by getMessageByCode
+        errorCodeMessagesTmp.put(0, "NT_STATUS_SUCCESS");
+
+        errorCodeMessages = Collections.unmodifiableMap(errorCodeMessagesTmp);
+        dosErrorCodeStatuses = Collections.unmodifiableMap(dosErrorCodeStatusesTmp);
+
+        Map<Integer, String> winErrorCodeMessagesTmp = new HashMap<>();
+        for (int i = 0; i < NtStatus.NT_STATUS_CODES.length; i++) {
+            winErrorCodeMessagesTmp.put(WinError.WINERR_CODES[i], WinError.WINERR_MESSAGES[i]);
+        }
+
+        winErrorCodeMessages = Collections.unmodifiableMap(winErrorCodeMessagesTmp);
+
+    }
+
+
+
 
 
     /**
@@ -54,88 +92,33 @@ public class SmbException extends CIFSException implements NtStatus, DosError, W
      * @internal
      */
     public static String getMessageByCode ( int errcode ) {
-        /*
-         * Note there's a signedness error here because 0xC0000000 based values are
-         * negative so it with NT_STATUS_SUCCESS (0) the binary search will not be
-         * performed properly. The effect is that the code at index 1 is never found
-         * (NT_STATUS_UNSUCCESSFUL). So here we factor out NT_STATUS_SUCCESS
-         * as a special case (which it is).
-         */
-        if ( errcode == 0 ) {
-            return "NT_STATUS_SUCCESS";
+        String message = errorCodeMessages.get(errcode);
+        if (message == null) {
+            message =  "0x" + Hexdump.toHexString(errcode, 8);
         }
-        if ( ( errcode & 0xC0000000 ) == 0xC0000000 ) {
-            int found = Arrays.binarySearch(NT_STATUS_CODES, errcode);
-            if ( found >= 0 && NT_STATUS_CODES[ found ] == errcode ) {
-                return NT_STATUS_MESSAGES[ found ];
-            }
-        }
-        else {
-            int min = 0;
-            int max = DOS_ERROR_CODES.length - 1;
-
-            while ( max >= min ) {
-                int mid = ( min + max ) / 2;
-
-                if ( errcode > DOS_ERROR_CODES[ mid ][ 0 ] ) {
-                    min = mid + 1;
-                }
-                else if ( errcode < DOS_ERROR_CODES[ mid ][ 0 ] ) {
-                    max = mid - 1;
-                }
-                else {
-                    return DOS_ERROR_MESSAGES[ mid ];
-                }
-            }
-        }
-        return "0x" + Hexdump.toHexString(errcode, 8);
+        return message;
     }
 
 
     static int getStatusByCode ( int errcode ) {
+        int statusCode;
         if ( ( errcode & 0xC0000000 ) != 0 ) {
-            return errcode;
+            statusCode = errcode;
+        } else if (dosErrorCodeStatuses.containsKey(errcode)) {
+            statusCode = dosErrorCodeStatuses.get(errcode);
+        } else {
+            statusCode = NT_STATUS_UNSUCCESSFUL;
         }
-
-        int min = 0;
-        int max = DOS_ERROR_CODES.length - 1;
-
-        while ( max >= min ) {
-            int mid = ( min + max ) / 2;
-
-            if ( errcode > DOS_ERROR_CODES[ mid ][ 0 ] ) {
-                min = mid + 1;
-            }
-            else if ( errcode < DOS_ERROR_CODES[ mid ][ 0 ] ) {
-                max = mid - 1;
-            }
-            else {
-                return DOS_ERROR_CODES[ mid ][ 1 ];
-            }
-        }
-        return NT_STATUS_UNSUCCESSFUL;
+        return statusCode;
     }
 
 
     static String getMessageByWinerrCode ( int errcode ) {
-        int min = 0;
-        int max = WINERR_CODES.length - 1;
-
-        while ( max >= min ) {
-            int mid = ( min + max ) / 2;
-
-            if ( errcode > WINERR_CODES[ mid ] ) {
-                min = mid + 1;
-            }
-            else if ( errcode < WINERR_CODES[ mid ] ) {
-                max = mid - 1;
-            }
-            else {
-                return WINERR_MESSAGES[ mid ];
-            }
+        String message = winErrorCodeMessages.get(errcode);
+        if (message == null) {
+            message = "W" + Hexdump.toHexString(errcode, 8);
         }
-
-        return "W" + Hexdump.toHexString(errcode, 8);
+        return message;
     }
 
     private int status;

--- a/src/main/java/jcifs/smb/SmbPipeHandleImpl.java
+++ b/src/main/java/jcifs/smb/SmbPipeHandleImpl.java
@@ -73,7 +73,7 @@ class SmbPipeHandleImpl implements SmbPipeHandleInternal {
         this.transact = ( pipe.getPipeType() & SmbPipeResource.PIPE_TYPE_TRANSACT ) == SmbPipeResource.PIPE_TYPE_TRANSACT;
         this.call = ( pipe.getPipeType() & SmbPipeResource.PIPE_TYPE_CALL ) == SmbPipeResource.PIPE_TYPE_CALL;
         this.openFlags = ( pipe.getPipeType() & 0xFFFF00FF ) | SmbConstants.O_EXCL;
-        this.access = ( pipe.getPipeType() >>> 16 ) & 0xFFFF | SmbConstants.FILE_WRITE_DATA | 0x20000;
+        this.access = (pipe.getPipeType() & 7) | 0x20000;
         this.uncPath = this.pipe.getUncPath();
     }
 

--- a/src/main/java/jcifs/smb/SmbTransportImpl.java
+++ b/src/main/java/jcifs/smb/SmbTransportImpl.java
@@ -1402,8 +1402,9 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
             throw new SmbAuthException(resp.getErrorCode());
         case NtStatus.NT_STATUS_MORE_PROCESSING_REQUIRED:
             break; /* normal for SPNEGO */
-        case 0x10B: // NT_STATUS_NOTIFY_CLEANUP
-        case 0x10C:
+        case 0x10B: // NT_STATUS_NOTIFY_CLEANUP:
+        case NtStatus.NT_STATUS_NOTIFY_ENUM_DIR:
+        case NtStatus.NT_STATUS_BUFFER_OVERFLOW:
             break;
         case 0xC00000BB: // NT_STATUS_NOT_SUPPORTED
             throw new SmbUnsupportedOperationException();


### PR DESCRIPTION
Related to https://github.com/AgNO3/jcifs-ng/issues/89

Also cleanup of some related error detection and error message lookup.
See https://msdn.microsoft.com/en-us/library/cc246722.aspx
