### PR TITLE
Failure decoding compounded messages & Add no more files status

### DIFF
--- a/src/main/java/jcifs/internal/smb2/ServerMessageBlock2.java
+++ b/src/main/java/jcifs/internal/smb2/ServerMessageBlock2.java
@@ -534,20 +534,14 @@ public abstract class ServerMessageBlock2 implements CommonServerMessageBlock {
     }
 
 
-    @Override
-    public int decode ( byte[] buffer, int bufferIndex ) throws SMBProtocolDecodingException {
-        return decode(buffer, bufferIndex, false);
-    }
-
-
     /**
      * @param buffer
      * @param bufferIndex
-     * @param compound
      * @return decoded length
      * @throws SMBProtocolDecodingException
      */
-    public int decode ( byte[] buffer, int bufferIndex, boolean compound ) throws SMBProtocolDecodingException {
+    @Override
+    public int decode ( byte[] buffer, int bufferIndex ) throws SMBProtocolDecodingException {
         int start = this.headerStart = bufferIndex;
         bufferIndex += readHeaderWireFormat(buffer, bufferIndex);
         if ( isErrorResponseStatus() ) {
@@ -560,7 +554,7 @@ public abstract class ServerMessageBlock2 implements CommonServerMessageBlock {
         this.length = bufferIndex - start;
         int len = this.length;
 
-        if ( compound || this.nextCommand != 0 ) {
+        if ( this.nextCommand != 0 ) {
             // padding becomes part of signature if this is _PART_ of a compound chain
             len += pad8(bufferIndex);
         }

--- a/src/main/java/jcifs/smb/NtStatus.java
+++ b/src/main/java/jcifs/smb/NtStatus.java
@@ -94,6 +94,7 @@ public interface NtStatus {
     public static final int NT_STATUS_CONNECTION_REFUSED = 0xC0000236;
     public static final int NT_STATUS_PATH_NOT_COVERED = 0xC0000257;
     public static final int NT_STATUS_IO_REPARSE_TAG_NOT_HANDLED = 0xC0000279;
+    public static final int NT_STATUS_NO_MORE_FILES = 0x80000006;
 
     static final int[] NT_STATUS_CODES = {
         NT_STATUS_OK, NT_STATUS_PENDING, NT_STATUS_UNSUCCESSFUL, NT_STATUS_NOT_IMPLEMENTED, NT_STATUS_INVALID_INFO_CLASS, NT_STATUS_ACCESS_VIOLATION,
@@ -110,7 +111,7 @@ public interface NtStatus {
         NT_STATUS_CANNOT_DELETE, NT_STATUS_INVALID_COMPUTER_NAME, NT_STATUS_PIPE_BROKEN, NT_STATUS_NO_SUCH_ALIAS, NT_STATUS_LOGON_TYPE_NOT_GRANTED,
         NT_STATUS_NO_TRUST_SAM_ACCOUNT, NT_STATUS_TRUSTED_DOMAIN_FAILURE, NT_STATUS_TRUSTED_RELATIONSHIP_FAILURE,
         NT_STATUS_NOLOGON_WORKSTATION_TRUST_ACCOUNT, NT_STATUS_PASSWORD_MUST_CHANGE, NT_STATUS_NOT_FOUND, NT_STATUS_ACCOUNT_LOCKED_OUT,
-        NT_STATUS_CONNECTION_REFUSED, NT_STATUS_PATH_NOT_COVERED, NT_STATUS_IO_REPARSE_TAG_NOT_HANDLED,
+        NT_STATUS_CONNECTION_REFUSED, NT_STATUS_PATH_NOT_COVERED, NT_STATUS_IO_REPARSE_TAG_NOT_HANDLED, NT_STATUS_NO_MORE_FILES,
     };
 
     static final String[] NT_STATUS_MESSAGES = {
@@ -142,5 +143,6 @@ public interface NtStatus {
         "The user must change his password before he logs on the first time.", "The object was not found.",
         "The referenced account is currently locked out and may not be logged on to.", "Connection refused",
         "The remote system is not reachable by the transport.", "The layered file system driver for this I/O tag did not handle it when needed.",
+        "No more files were found that match the file specification.",
     };
 }

--- a/src/main/java/jcifs/smb/SmbTransportImpl.java
+++ b/src/main/java/jcifs/smb/SmbTransportImpl.java
@@ -1381,6 +1381,7 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
         boolean cont = false;
         switch ( resp.getErrorCode() ) {
         case NtStatus.NT_STATUS_OK:
+        case NtStatus.NT_STATUS_NO_MORE_FILES:
             cont = true;
             break;
         case NtStatus.NT_STATUS_PENDING:

--- a/src/main/java/jcifs/smb/SmbTransportImpl.java
+++ b/src/main/java/jcifs/smb/SmbTransportImpl.java
@@ -1203,7 +1203,7 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
 
                 readn(this.in, buffer, Smb2Constants.SMB2_HEADER_LENGTH, rl - Smb2Constants.SMB2_HEADER_LENGTH);
 
-                len = cur.decode(buffer, 0, true);
+                len = cur.decode(buffer, 0);
                 if ( len > rl ) {
                     throw new IOException(String.format("WHAT? ( read %d decoded %d ): %s", rl, len, cur));
                 }


### PR DESCRIPTION
This contains 2 different issues:

1. Failure decoding compounded messages:
I got this exception:
`2018-09-02 10:22:41.247 WARN [jcifs.smb.SmbTransportImpl] (Transport0) Failure decoding message, disconnecting transport java.io.IOException: WHAT? ( read 124 decoded 128 ): command=SMB2_CLOSE,status=0,flags=0x0005,mid=18,wordCount=0,byteCount=0 at jcifs.smb.SmbTransportImpl.doRecvSMB2(SmbTransportImpl.java:1212) at jcifs.smb.SmbTransportImpl.doRecv(SmbTransportImpl.java:1125) at jcifs.util.transport.Transport.loop(Transport.java:459) at jcifs.util.transport.Transport.run(Transport.java:762) at java.lang.Thread.run(Thread.java:748) 2018-09-02 10:23:11.242 WARN [jcifs.util.transport.Transport] (default task-14) sendrecv failed jcifs.util.transport.RequestTimeoutException: Transport0 timedout waiting for response to command=SMB2_TREE_CONNECT,status=0,flags=0x0000,mid=19,wordCount=0,byteCount=56 at jcifs.util.transport.Transport.waitForResponses(Transport.java:365) at jcifs.util.transport.Transport.sendrecv(Transport.java:232) at jcifs.smb.SmbTransportImpl.sendrecv(SmbTransportImpl.java:1003) at jcifs.smb.SmbTransportImpl.send(SmbTransportImpl.java:1520) at jcifs.smb.SmbSessionImpl.send(SmbSessionImpl.java:407) at jcifs.smb.SmbSessionImpl.send(SmbSessionImpl.java:345) at jcifs.smb.SmbTreeImpl.treeConnect(SmbTreeImpl.java:607) at jcifs.smb.SmbTreeConnection.connectTree(SmbTreeConnection.java:609) at jcifs.smb.SmbTreeConnection.connectHost(SmbTreeConnection.java:563) at jcifs.smb.SmbTreeConnection.connectHost(SmbTreeConnection.java:484) at jcifs.smb.SmbTreeConnection.connect(SmbTreeConnection.java:460) at jcifs.smb.SmbTreeConnection.connectWrapException(SmbTreeConnection.java:421) at jcifs.smb.SmbFile.ensureTreeConnected(SmbFile.java:550) at jcifs.smb.SmbFile.getType(SmbFile.java:877)`

So I start look at the SMB documentation and I found that :
https://msdn.microsoft.com/en-us/library/cc246614.aspx
> the last request of the compounded requests does not need to be padded to an 8-byte boundary. 

I also think that this is related to #80 


2. Add no more files status:
Add STATUS_NO_MORE_FILES witch is a OK answer in response for find request
https://wiki.wireshark.org/SMB2/Find