### PR TITLE
Use all available data when feching size or attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,8 @@ hs_err_pid*
 .project
 .settings
 
+# intellij
+*.iml
+.idea/
+
 .repository


### PR DESCRIPTION
Currently when the server supports smb2 an SMB2-CREATE Request is made when you call `length()`, `exists()`, `lastModified()` ... . However not all data in the [SMB2 CREATE Response](https://msdn.microsoft.com/en-us/library/cc246512.aspx) is used. When calling `length()` only the size gets stored and when calling the other methods the other attributes are stored.

Therefore I updated the following:
- the `withOpen()` function now updates the `sizeExpiration` (for whatever reason it did not do that)
- the functions calling `queryPath()` no longer set the attributes. It's now done inside the function
- when the server supports smb2 the `queryPath()` function just calles `withOpen()`
- removed the `queryPath()` call from `delete(name)` and added a fail-fast if file does not exist
- removed the `queryPath()` call from `copyRecursive()` and added a fail-fast to `copyTo()` if file does not exist
- added fail-fast to `renameTo()` if file does not exist
- added fail-fast to `setPathInformation()` if file does not exist

Also I updated the `.gitignore` for IntelliJ IDEA