### PR TITLE
support empty notification (can happen if server decides)

### DIFF
--- a/src/main/java/jcifs/internal/smb1/trans/nt/FileNotifyInformationImpl.java
+++ b/src/main/java/jcifs/internal/smb1/trans/nt/FileNotifyInformationImpl.java
@@ -84,6 +84,10 @@ public class FileNotifyInformationImpl implements FileNotifyInformation, Decodab
 
     @Override
     public int decode ( byte[] buffer, int bufferIndex, int len ) throws SMBProtocolDecodingException {
+        if (len == 0) {
+        	// nothing to do
+        	return 0;
+        }
         int start = bufferIndex;
 
         this.nextEntryOffset = SMBUtil.readInt4(buffer, bufferIndex);


### PR DESCRIPTION
I've tested cifs notification and saw the cifs server generated empty notifications under stress - here the fix, Cheers.