### PR TITLE
fixed #126 keep connections to be closed in a temporary list and process outside synchronized block.

### DIFF
--- a/src/main/java/jcifs/smb/SmbTransportPoolImpl.java
+++ b/src/main/java/jcifs/smb/SmbTransportPoolImpl.java
@@ -271,20 +271,22 @@ public class SmbTransportPoolImpl implements SmbTransportPool {
     @Override
     public boolean close () throws CIFSException {
         boolean inUse = false;
+        
+        List<SmbTransportImpl> toClose;
         synchronized ( this.connections ) {
             log.debug("Closing pool");
-            List<SmbTransportImpl> toClose = new LinkedList<>(this.connections);
+            toClose = new LinkedList<>(this.connections);
             toClose.addAll(this.nonPooledConnections);
-            for ( SmbTransportImpl conn : toClose ) {
-                try {
-                    inUse |= conn.disconnect(false, false);
-                }
-                catch ( IOException e ) {
-                    log.warn("Failed to close connection", e);
-                }
-            }
             this.connections.clear();
             this.nonPooledConnections.clear();
+        }
+        for ( SmbTransportImpl conn : toClose ) {
+            try {
+                inUse |= conn.disconnect(false, false);
+            }
+            catch ( IOException e ) {
+                log.warn("Failed to close connection", e);
+            }
         }
         return inUse;
     }


### PR DESCRIPTION
Hi,

first pull-request ever, so be nice to me in case I've done something wrong ;-) As already stated in my issue report the fix of the particular deadlock I reported should be to perform the closing operation outside the synchronized block that was used to create the already existing temporary list.