### PR TITLE
NegTokenInit and DCERPC bugs

### DIFF
--- a/src/main/java/jcifs/spnego/NegTokenInit.java
+++ b/src/main/java/jcifs/spnego/NegTokenInit.java
@@ -48,13 +48,13 @@ import jcifs.util.Hexdump;
 @SuppressWarnings ( "javadoc" )
 public class NegTokenInit extends SpnegoToken {
 
-    public static final int DELEGATION = 0x40;
-    public static final int MUTUAL_AUTHENTICATION = 0x20;
-    public static final int REPLAY_DETECTION = 0x10;
-    public static final int SEQUENCE_CHECKING = 0x08;
-    public static final int ANONYMITY = 0x04;
-    public static final int CONFIDENTIALITY = 0x02;
-    public static final int INTEGRITY = 0x01;
+    public static final int DELEGATION = 0x80;
+    public static final int MUTUAL_AUTHENTICATION = 0x40;
+    public static final int REPLAY_DETECTION = 0x20;
+    public static final int SEQUENCE_CHECKING = 0x10;
+    public static final int ANONYMITY = 0x08;
+    public static final int CONFIDENTIALITY = 0x04;
+    public static final int INTEGRITY = 0x02;
 
     private static final ASN1ObjectIdentifier SPNEGO_OID = new ASN1ObjectIdentifier(SpnegoConstants.SPNEGO_MECHANISM);
 


### PR DESCRIPTION
Hi, please check my pull request.

The first issue is on NegTokenInit  context flags values (involved src/main/java/jcifs/spnego/NegTokenInit.java)

The second is on handling file servers with many (100~) shears DCERPC messages (involved src/main/java/jcifs/dcerpc/DcerpcPipeHandle.java and src/main/java/jcifs/dcerpc/DcerpcHandle.java)