### PR TITLE
jcifs.RuntimeCIFSException: Usage count dropped below zero

### DIFF
--- a/src/main/java/jcifs/smb/SmbSessionImpl.java
+++ b/src/main/java/jcifs/smb/SmbSessionImpl.java
@@ -178,9 +178,11 @@ final class SmbSessionImpl implements SmbSessionInternal {
         }
 
         if ( usage == 1 ) {
-            if ( this.transportAcquired.compareAndSet(false, true) ) {
-                log.debug("Reacquire transport");
-                this.transport.acquire();
+            synchronized (this) {
+                if (this.transportAcquired.compareAndSet(false, true)) {
+                    log.debug("Reacquire transport");
+                    this.transport.acquire();
+                }
             }
         }
 


### PR DESCRIPTION
Missing synchronization on SmbSessionImpl#acquire() causes 'jcifs.RuntimeCIFSException: Usage count dropped below zero' while SmbTransportImple#release() due to race condition. See below for the detail.

https://htmlpreview.github.io/?https://github.com/takifujis/jcifs-ng/blob/tmp/SmbSessionImpl_acquire_release_race_condition.html