### PR TITLE
Bug Fixes

### DIFF
--- a/src/main/java/jcifs/smb/Handler.java
+++ b/src/main/java/jcifs/smb/Handler.java
@@ -96,6 +96,14 @@ public class Handler extends URLStreamHandler {
         else if ( spec.startsWith("smb://") == false && host != null && host.length() == 0 ) {
             spec = "//" + spec;
             limit += 2;
+        } else {
+        	// TODO: verify that this is a valid rule!
+        	// Change made to fix problems when deleting directory children recursively        	
+        	if (u.getPath() != null) {
+        		String separator = u.getPath().endsWith("/") || spec.startsWith("/") ? "" : "/";
+    			spec = u.getPath() + separator + spec;
+    			limit = spec.length();
+        	}
         }
         super.parseURL(u, spec, start, limit);
         path = u.getPath();
@@ -109,4 +117,5 @@ public class Handler extends URLStreamHandler {
         }
         setURL(u, "smb", u.getHost(), port, u.getAuthority(), u.getUserInfo(), path, u.getQuery(), null);
     }
+
 }

--- a/src/main/java/jcifs/smb/SmbResourceLocatorImpl.java
+++ b/src/main/java/jcifs/smb/SmbResourceLocatorImpl.java
@@ -163,8 +163,12 @@ class SmbResourceLocatorImpl implements SmbResourceLocatorInternal, Cloneable {
                 this.share = shr;
             }
             else {
-                this.unc = uncPath + name.replace('/', '\\') + ( trailingSlash ? "\\" : "" );
-                this.canon = context.getURLPath() + name + ( trailingSlash ? "/" : "" );
+            	// Make sure there's a file separator between uncPath and name.
+            	String separator = (uncPath.endsWith("\\") || name.startsWith("/")) ? "" : "\\";
+                this.unc = uncPath + separator + name.replace('/', '\\') + ( trailingSlash ? "\\" : "" );
+                // Make sure there's a file separator between context's url path and name
+                separator = (context.getURLPath().endsWith("/") || name.startsWith("/")) ? "" : "/";
+                this.canon = context.getURLPath() + separator + name + ( trailingSlash ? "/" : "" );
                 this.share = shr;
             }
         }


### PR DESCRIPTION
- URL Handler: parseUrl was not parsing URLs correctly when deleting
files recursively

- Resource Locator Implementation: paths and names were concatenated
without path separator in method resolveInContext