### PR TITLE
NameServiceClientImpl.java - WINS was not used even when explicitly specified in "jcifs.netbios.wins"

### DIFF
--- a/src/main/java/jcifs/netbios/NameServiceClientImpl.java
+++ b/src/main/java/jcifs/netbios/NameServiceClientImpl.java
@@ -423,7 +423,8 @@ public class NameServiceClientImpl implements Runnable, NameServiceClient {
 
         if ( max == 0 ) {
             max = 1; /* No WINs, try only bcast addr */
-        }
+        } else
+            request.addr = getWINSAddress();
 
         synchronized ( response ) {
             while ( max-- > 0 ) {


### PR DESCRIPTION
While debugging I was quite frustrating that the master browser is constantly migrates between my network's nodes, so I decided to try to setup a WINS server. However, I noticed JCIFS-NG never tries to access it even though jcifs.resolveOrder is set to "WINS".
This apparently happens because the method NameServiceClientImpl.send() only calls getWINSAddress() after the first failed attempt, not before.


