### PR TITLE
Use url handler from provided context when creating SmbFile

### DIFF
--- a/src/main/java/jcifs/smb/Handler.java
+++ b/src/main/java/jcifs/smb/Handler.java
@@ -39,7 +39,6 @@ import jcifs.context.SingletonContext;
 public class Handler extends URLStreamHandler {
 
     private static final Logger log = LoggerFactory.getLogger(Handler.class);
-    static final URLStreamHandler SMB_HANDLER = new Handler();
     private CIFSContext transportContext;
 
 

--- a/src/main/java/jcifs/smb/SmbFile.java
+++ b/src/main/java/jcifs/smb/SmbFile.java
@@ -460,7 +460,7 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
     SmbFile ( SmbResource context, String name, boolean loadedAttributes, int type, int attributes, long createTime, long lastModified,
             long lastAccess, long size ) throws MalformedURLException {
         this(
-            isWorkgroup(context) ? new URL(null, "smb://" + checkName(name) + "/", Handler.SMB_HANDLER)
+            isWorkgroup(context) ? new URL(null, "smb://" + checkName(name) + "/", context.getContext().getUrlHandler())
                     : new URL(
                         context.getLocator().getURL(),
                         encodeRelativePath(checkName(name)) + ( ( attributes & ATTR_DIRECTORY ) > 0 ? "/" : "" )),


### PR DESCRIPTION
This makes the constructor more consistent to other constructors (e. g. https://github.com/AgNO3/jcifs-ng/blob/master/src/main/java/jcifs/smb/SmbFile.java#L421)