### PR TITLE
Requesting permissions that aren't actually needed caused Access is Denied errors on Dell/EMC NAS devices

### DIFF
--- a/src/main/java/jcifs/SmbConstants.java
+++ b/src/main/java/jcifs/SmbConstants.java
@@ -122,6 +122,7 @@ public interface SmbConstants {
     static final int WRITE_DAC = 0x00040000; // 18
     static final int WRITE_OWNER = 0x00080000; // 19
     static final int SYNCHRONIZE = 0x00100000; // 20
+    static final int MAXIMUM_ALLOWED = 0x02000000; // 25
     static final int GENERIC_ALL = 0x10000000; // 28
     static final int GENERIC_EXECUTE = 0x20000000; // 29
     static final int GENERIC_WRITE = 0x40000000; // 30

--- a/src/main/java/jcifs/internal/smb2/create/Smb2CreateRequest.java
+++ b/src/main/java/jcifs/internal/smb2/create/Smb2CreateRequest.java
@@ -20,6 +20,7 @@ package jcifs.internal.smb2.create;
 
 import java.nio.charset.StandardCharsets;
 
+import jcifs.SmbConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,6 +31,8 @@ import jcifs.internal.smb2.ServerMessageBlock2Request;
 import jcifs.internal.smb2.Smb2Constants;
 import jcifs.internal.util.SMBUtil;
 import jcifs.util.Hexdump;
+
+import static jcifs.SmbConstants.MAXIMUM_ALLOWED;
 
 
 /**
@@ -210,7 +213,7 @@ public class Smb2CreateRequest extends ServerMessageBlock2Request<Smb2CreateResp
     private byte requestedOplockLevel = SMB2_OPLOCK_LEVEL_NONE;
     private int impersonationLevel = SMB2_IMPERSONATION_LEVEL_IMPERSONATION;
     private long smbCreateFlags;
-    private int desiredAccess = 0x00120089; // 0x80000000 | 0x1;
+    private int desiredAccess = MAXIMUM_ALLOWED;
     private int fileAttributes;
     private int shareAccess = FILE_SHARE_READ | FILE_SHARE_WRITE;
     private int createDisposition = FILE_OPEN;

--- a/src/main/java/jcifs/smb/SmbFile.java
+++ b/src/main/java/jcifs/smb/SmbFile.java
@@ -1708,7 +1708,7 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
 
     protected <T extends ServerMessageBlock2Response> T withOpen ( SmbTreeHandleImpl th, ServerMessageBlock2Request<T> first,
             ServerMessageBlock2Request<?>... others ) throws CIFSException {
-        return withOpen(th, Smb2CreateRequest.FILE_OPEN, 0x00120089, SmbConstants.FILE_SHARE_READ | SmbConstants.FILE_SHARE_WRITE, first, others);
+        return withOpen(th, Smb2CreateRequest.FILE_OPEN, MAXIMUM_ALLOWED, SmbConstants.FILE_SHARE_READ | SmbConstants.FILE_SHARE_WRITE, first, others);
     }
 
 


### PR DESCRIPTION
We've had several customers that get "Access is Denied" errors accessing shares Dell/EMC NAS devices running OneFS that are accessible from a Windows device. The only way we have been able to get access to work without that error from JCIFS-NG is to force SMB1 protocol, which is obviously suboptimal. I finally tracked down the problem as being related to the way OneFS maps between Unix and NTFS permissions models, which does not map Unix Read permission to include the READ_CONTROL permission that Windows high level read includes. This causes the Access is Denied error from SmbFIle.listFiles() and SmbFile.exists() (and probably several other places) because they request a default set of permissions which include READ_CONTROL. What seemed like the most natural fix was to change this to use MAXIMUM_ALLOWED bit, which adapts itself to the permissions that the user actually has, which would defer any Access is Denied errors until a request that actually needs that permission. This also more closely resembles the behavior of SMBv1.

Note that this problem doesn't require a NAS device to duplicate. The same conditions can be set explicitly on a Windows server using ACL's.