### PR TITLE
when a file is locked for write, can't check if it exists, or check size

### DIFF
--- a/src/main/java/jcifs/smb/SmbFile.java
+++ b/src/main/java/jcifs/smb/SmbFile.java
@@ -774,7 +774,8 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
          */
 
         if ( th.isSMB2() ) {
-            return (SmbBasicFileInfo) withOpen(th, null); // just open and close. withOpen will store the attributes
+        	// just open and close. withOpen will store the attributes
+        	return (SmbBasicFileInfo) withOpen(th, Smb2CreateRequest.FILE_OPEN, 0x00000080, SmbConstants.FILE_SHARE_READ | SmbConstants.FILE_SHARE_WRITE, null);
         }
         else if ( th.hasCapability(SmbConstants.CAP_NT_SMBS) ) {
             /*

--- a/src/test/java/jcifs/tests/AllTests.java
+++ b/src/test/java/jcifs/tests/AllTests.java
@@ -56,7 +56,7 @@ import jcifs.context.BaseContext;
 @SuiteClasses ( {
     ContextConfigTest.class, PACTest.class, NtlmTest.class, FileLocationTest.class, SessionTest.class, KerberosTest.class, TimeoutTest.class,
     SidTest.class, NamingTest.class, DfsTest.class, FileAttributesTest.class, EnumTest.class, PipeTest.class, FileOperationsTest.class,
-    WatchTest.class, ReadWriteTest.class, ConcurrencyTest.class, RandomAccessFileTest.class, OplockTests.class
+    WatchTest.class, ReadWriteTest.class, ConcurrencyTest.class, RandomAccessFileTest.class, OplockTests.class, InfoOnLock.class
 } )
 
 public class AllTests {

--- a/src/test/java/jcifs/tests/InfoOnLock.java
+++ b/src/test/java/jcifs/tests/InfoOnLock.java
@@ -59,7 +59,6 @@ public class InfoOnLock extends BaseCIFSTest {
     @Test
     public void testExistsOnLock () throws IOException {
         try ( SmbFile f = createTestFile() ) {
-        	System.out.println("created file: " + f.getCanonicalPath());
             SmbFileOutputStream ostream = f.openOutputStream(true, SmbConstants.FILE_NO_SHARE);
             SmbFile checkFile = new SmbFile(f.getCanonicalPath(), f.getContext());
 
@@ -76,7 +75,6 @@ public class InfoOnLock extends BaseCIFSTest {
     @Test
     public void testSizeOnLock () throws IOException {
         try ( SmbFile f = createTestFile() ) {
-        	System.out.println("created file: " + f.getCanonicalPath());
             SmbFileOutputStream ostream = f.openOutputStream(true, SmbConstants.FILE_NO_SHARE);
             SmbFile checkFile = new SmbFile(f.getCanonicalPath(), f.getContext());
             try {

--- a/src/test/java/jcifs/tests/InfoOnLock.java
+++ b/src/test/java/jcifs/tests/InfoOnLock.java
@@ -1,0 +1,92 @@
+/*
+ * © 2016 AgNO3 Gmbh & Co. KG
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package jcifs.tests;
+
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import jcifs.SmbConstants;
+import jcifs.smb.SmbFile;
+import jcifs.smb.SmbFileOutputStream;
+
+
+/**
+ * 
+ * 
+ * 
+ * @author Ilan Goldfeld
+ */
+@RunWith ( Parameterized.class )
+@SuppressWarnings ( "javadoc" )
+public class InfoOnLock extends BaseCIFSTest {
+
+    public InfoOnLock ( String name, Map<String, String> properties ) {
+        super(name, properties);
+    }
+    
+    @Parameters ( name = "{0}" )
+    public static Collection<Object> configs () {
+        return getConfigs("smb1", "noUnicode", "forceUnicode", "noNTStatus", "noNTSmbs", "smb2", "smb30", "smb31");
+    }
+
+    
+
+    @Test
+    public void testExistsOnLock () throws IOException {
+        try ( SmbFile f = createTestFile() ) {
+        	System.out.println("created file: " + f.getCanonicalPath());
+            SmbFileOutputStream ostream = f.openOutputStream(true, SmbConstants.FILE_NO_SHARE);
+            SmbFile checkFile = new SmbFile(f.getCanonicalPath(), f.getContext());
+
+            try {
+            	assertTrue(checkFile.exists());
+            } finally {
+                ostream.close();
+                checkFile.close();
+                f.delete();
+            }
+        }
+    }
+    
+    @Test
+    public void testSizeOnLock () throws IOException {
+        try ( SmbFile f = createTestFile() ) {
+        	System.out.println("created file: " + f.getCanonicalPath());
+            SmbFileOutputStream ostream = f.openOutputStream(true, SmbConstants.FILE_NO_SHARE);
+            SmbFile checkFile = new SmbFile(f.getCanonicalPath(), f.getContext());
+            try {
+            	assertNotEquals(checkFile.length(), -1);
+            } finally {
+                ostream.close();
+                checkFile.close();
+                f.delete();
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
The request to check that file exists, or for file length, is done by requesting to open the file with read access.
However if the file is locked, an exception is thrown when trying to check for file existence / length.

I added a test class that shows the exact scenario.