### PR TITLE
Change DEROutputStream to ASN1OutputStream.create(out, DER)

### DIFF
--- a/src/main/java/jcifs/smb/SpnegoContext.java
+++ b/src/main/java/jcifs/smb/SpnegoContext.java
@@ -21,8 +21,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 
+import org.bouncycastle.asn1.ASN1Encoding;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.asn1.DEROutputStream;
+import org.bouncycastle.asn1.ASN1OutputStream;
 import org.bouncycastle.asn1.DERSequence;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -366,7 +367,7 @@ class SpnegoContext implements SSPContext {
     private static byte[] encodeMechs ( ASN1ObjectIdentifier[] mechs ) throws CIFSException {
         try {
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            DEROutputStream dos = new DEROutputStream(bos);
+            ASN1OutputStream dos = ASN1OutputStream.create(bos, ASN1Encoding.DER);
             dos.writeObject(new DERSequence(mechs));
             dos.close();
             return bos.toByteArray();

--- a/src/main/java/jcifs/spnego/NegTokenInit.java
+++ b/src/main/java/jcifs/spnego/NegTokenInit.java
@@ -25,21 +25,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Enumeration;
 
-import org.bouncycastle.asn1.ASN1ApplicationSpecific;
-import org.bouncycastle.asn1.ASN1BitString;
-import org.bouncycastle.asn1.ASN1EncodableVector;
-import org.bouncycastle.asn1.ASN1InputStream;
-import org.bouncycastle.asn1.ASN1Object;
-import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.asn1.ASN1OctetString;
-import org.bouncycastle.asn1.ASN1Sequence;
-import org.bouncycastle.asn1.ASN1TaggedObject;
-import org.bouncycastle.asn1.DERApplicationSpecific;
-import org.bouncycastle.asn1.DERBitString;
-import org.bouncycastle.asn1.DEROctetString;
-import org.bouncycastle.asn1.DEROutputStream;
-import org.bouncycastle.asn1.DERSequence;
-import org.bouncycastle.asn1.DERTaggedObject;
+import org.bouncycastle.asn1.*;
 
 import jcifs.util.Hexdump;
 
@@ -155,7 +141,7 @@ public class NegTokenInit extends SpnegoToken {
             ev.add(SPNEGO_OID);
             ev.add(new DERTaggedObject(true, 0, new DERSequence(fields)));
             ByteArrayOutputStream collector = new ByteArrayOutputStream();
-            DEROutputStream der = new DEROutputStream(collector);
+            ASN1OutputStream der = ASN1OutputStream.create(collector, ASN1Encoding.DER);
             DERApplicationSpecific derApplicationSpecific = new DERApplicationSpecific(0, ev);
             der.writeObject(derApplicationSpecific);
             return collector.toByteArray();

--- a/src/main/java/jcifs/spnego/NegTokenTarg.java
+++ b/src/main/java/jcifs/spnego/NegTokenTarg.java
@@ -25,14 +25,15 @@ import java.io.IOException;
 import java.util.Enumeration;
 
 import org.bouncycastle.asn1.ASN1EncodableVector;
+import org.bouncycastle.asn1.ASN1Encoding;
 import org.bouncycastle.asn1.ASN1Enumerated;
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1OctetString;
+import org.bouncycastle.asn1.ASN1OutputStream;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.ASN1TaggedObject;
 import org.bouncycastle.asn1.DEROctetString;
-import org.bouncycastle.asn1.DEROutputStream;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.DERTaggedObject;
 
@@ -91,7 +92,7 @@ public class NegTokenTarg extends SpnegoToken {
     public byte[] toByteArray () {
         try {
             ByteArrayOutputStream collector = new ByteArrayOutputStream();
-            DEROutputStream der = new DEROutputStream(collector);
+            ASN1OutputStream der = ASN1OutputStream.create(collector, ASN1Encoding.DER);
             ASN1EncodableVector fields = new ASN1EncodableVector();
             int res = getResult();
             if ( res != UNSPECIFIED_RESULT ) {


### PR DESCRIPTION
To prevent breaking jcifs when updating bouncycastle.

Reference: [org.bouncycastle.asn1.DEROutputStream](https://github.com/bcgit/bc-java/blob/r1rv66/core/src/main/java/org/bouncycastle/asn1/DEROutputStream.java)