### PR TITLE
provide mechanism to register custom secutity provider

### DIFF
--- a/src/main/java/jcifs/internal/smb2/Smb2SigningDigest.java
+++ b/src/main/java/jcifs/internal/smb2/Smb2SigningDigest.java
@@ -20,12 +20,11 @@ package jcifs.internal.smb2;
 
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
-import java.security.Provider;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import jcifs.util.Crypto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,9 +48,6 @@ public class Smb2SigningDigest implements SMBSigningDigest {
     private static final int SIGNATURE_LENGTH = 16;
     private final Mac digest;
 
-    private static final Provider BC = new BouncyCastleProvider();
-
-
     /**
      * @param sessionKey
      * @param dialect
@@ -71,14 +67,14 @@ public class Smb2SigningDigest implements SMBSigningDigest {
         case Smb2Constants.SMB2_DIALECT_0300:
         case Smb2Constants.SMB2_DIALECT_0302:
             signingKey = Smb3KeyDerivation.deriveSigningKey(dialect, sessionKey, new byte[0] /* unimplemented */);
-            m = Mac.getInstance("AESCMAC", BC);
+            m = Mac.getInstance("AESCMAC", Crypto.getProvider());
             break;
         case Smb2Constants.SMB2_DIALECT_0311:
             if ( preauthIntegrityHash == null ) {
                 throw new IllegalArgumentException("Missing preauthIntegrityHash for SMB 3.1");
             }
             signingKey = Smb3KeyDerivation.deriveSigningKey(dialect, sessionKey, preauthIntegrityHash);
-            m = Mac.getInstance("AESCMAC", BC);
+            m = Mac.getInstance("AESCMAC", Crypto.getProvider());
             break;
         default:
             throw new IllegalArgumentException("Unknown dialect");

--- a/src/main/java/jcifs/util/Crypto.java
+++ b/src/main/java/jcifs/util/Crypto.java
@@ -21,6 +21,7 @@ package jcifs.util;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
 
 import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
@@ -37,7 +38,7 @@ import jcifs.CIFSUnsupportedCryptoException;
  */
 public final class Crypto {
 
-    private static final BouncyCastleProvider BCPROV = new BouncyCastleProvider();
+    private static Provider provider = null;
 
 
     /**
@@ -52,7 +53,7 @@ public final class Crypto {
      */
     public static MessageDigest getMD4 () {
         try {
-            return MessageDigest.getInstance("MD4", BCPROV);
+            return MessageDigest.getInstance("MD4", getProvider());
         }
         catch ( NoSuchAlgorithmException e ) {
             throw new CIFSUnsupportedCryptoException(e);
@@ -162,4 +163,29 @@ public final class Crypto {
         return key8;
     }
 
+    /**
+     * Default provider is BouncyCastleProvider.
+     * For registering custom provider
+     * @see jcifs.util.Crypto#initProvider(Provider)
+     * @return Provider
+     */
+    public static Provider getProvider() {
+        if (provider != null) {
+            return provider;
+        }
+        provider = new BouncyCastleProvider();
+        return provider;
+    }
+
+    /**
+     * Initialize Provider Instance with customProvider
+     * @param customProvider
+     * @throws Exception if Provider has already been initialized.
+     */
+    public static void initProvider(Provider customProvider) throws CIFSUnsupportedCryptoException {
+        if (provider != null) {
+            throw new CIFSUnsupportedCryptoException("Provider can't be re-initialized. Provider has already been initialized with "+ provider.getInfo());
+        }
+        provider = customProvider;
+    }
 }


### PR DESCRIPTION
This PR provide a mechanism via which we can register the custom security provider from outside of library. This will help the use cases where one want to use their custom provider for security operation like getting MessageDigest, Mac,Cipher etc. It also decouple the library from BouncyCastleProvider().