### PR TITLE
Allowing tree ids of at least 0 in validation

### DIFF
--- a/src/main/java/jcifs/internal/smb2/tree/Smb2TreeConnectResponse.java
+++ b/src/main/java/jcifs/internal/smb2/tree/Smb2TreeConnectResponse.java
@@ -199,7 +199,7 @@ public class Smb2TreeConnectResponse extends ServerMessageBlock2Response impleme
 
     @Override
     public boolean isValidTid () {
-        return getTreeId() != 0;
+        return getTreeId() >= 0;
     }
 
 


### PR DESCRIPTION
The `isValidTid` method should allow tree ids that are 0. 

resolves #303 