### PR TITLE
Return DFS referrals in order

### DIFF
--- a/src/main/java/jcifs/smb/SmbTransportImpl.java
+++ b/src/main/java/jcifs/smb/SmbTransportImpl.java
@@ -1741,6 +1741,7 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
                 rn = dfsResp.getNumReferrals();
             }
 
+            DfsReferralDataImpl head = null;
             DfsReferralDataImpl cur = null;
             long expiration = System.currentTimeMillis() + ( ctx.getConfig().getDfsTtl() * 1000 );
             Referral[] refs = dfsResp.getReferrals();
@@ -1754,6 +1755,7 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
                 }
 
                 if ( cur == null ) {
+                    head = dr;
                     cur = dr;
                 }
                 else {
@@ -1763,9 +1765,9 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
             }
 
             if ( log.isDebugEnabled() ) {
-                log.debug("Got referral " + cur);
+                log.debug("Got referral " + head);
             }
-            return cur;
+            return head;
         }
     }
 


### PR DESCRIPTION
In the current logic the last referral is returned first, which is counterintuitive if you have your DFS set up to return referrals in
the order of closest to the caller.