### PR TITLE
build(deps): upgrade bcprov-jdk18on

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk18on</artifactId>
-			<version>1.76</version>
+			<version>1.81</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
1.76 is vulnerable via [CVE-2024-30172](https://nvd.nist.gov/vuln/detail/cve-2024-30172), 1.81 is [latest release](https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on).

Have not tried building, but hope CI can give a green light if the upgrade is OK.