### PR TITLE
fix SMB2 multi-credit I/O negotiation and sequencing

### DIFF
--- a/src/main/java/jcifs/BufferCache.java
+++ b/src/main/java/jcifs/BufferCache.java
@@ -34,6 +34,12 @@ public interface BufferCache {
 
 
     /**
+     * @return the maximum size of buffers in this cache
+     */
+    int getMaximumBufferSize ();
+
+
+    /**
      * Return a buffer to the cache
      * 
      * @param buf

--- a/src/main/java/jcifs/BufferCache.java
+++ b/src/main/java/jcifs/BufferCache.java
@@ -34,12 +34,6 @@ public interface BufferCache {
 
 
     /**
-     * @return the maximum size of buffers in this cache
-     */
-    int getMaximumBufferSize ();
-
-
-    /**
      * Return a buffer to the cache
      * 
      * @param buf

--- a/src/main/java/jcifs/internal/smb1/ServerMessageBlock.java
+++ b/src/main/java/jcifs/internal/smb1/ServerMessageBlock.java
@@ -405,12 +405,17 @@ public abstract class ServerMessageBlock implements CommonServerMessageBlockRequ
     }
 
 
+    @Override
+    public void setCreditCharge ( int cost ) {}
+
+
     /**
      * {@inheritDoc}
      *
      * @see jcifs.util.transport.Request#setRequestCredits(int)
      */
     @Override
+
     public void setRequestCredits ( int credits ) {
 
     }

--- a/src/main/java/jcifs/internal/smb1/ServerMessageBlock.java
+++ b/src/main/java/jcifs/internal/smb1/ServerMessageBlock.java
@@ -404,8 +404,6 @@ public abstract class ServerMessageBlock implements CommonServerMessageBlockRequ
         return 1;
     }
 
-
-    @Override
     public void setCreditCharge ( int cost ) {}
 
 

--- a/src/main/java/jcifs/internal/smb2/ServerMessageBlock2.java
+++ b/src/main/java/jcifs/internal/smb2/ServerMessageBlock2.java
@@ -27,6 +27,9 @@ import jcifs.internal.util.SMBUtil;
 import jcifs.smb.SmbException;
 import jcifs.util.Hexdump;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * 
@@ -34,6 +37,8 @@ import jcifs.util.Hexdump;
  *
  */
 public abstract class ServerMessageBlock2 implements CommonServerMessageBlock {
+
+    private static final Logger log = LoggerFactory.getLogger(ServerMessageBlock2.class);
 
     /*
      * These are all the smbs supported by this library. This includes requests
@@ -96,7 +101,8 @@ public abstract class ServerMessageBlock2 implements CommonServerMessageBlock {
 
     private int command;
     private int flags;
-    private int length, headerStart, wordCount, byteCount;
+    private int length, wordCount, byteCount;
+    protected int headerStart;
 
     private byte[] signature = new byte[16];
     private Smb2SigningDigest digest = null;
@@ -251,6 +257,15 @@ public abstract class ServerMessageBlock2 implements CommonServerMessageBlock {
      */
     public final int getCreditCharge () {
         return this.creditCharge;
+    }
+
+
+    /**
+     * @param creditCharge
+     *            the creditCharge to set
+     */
+    public final void setCreditCharge ( int creditCharge ) {
+        this.creditCharge = creditCharge;
     }
 
 
@@ -680,6 +695,11 @@ public abstract class ServerMessageBlock2 implements CommonServerMessageBlock {
         bufferIndex += 4;
         this.mid = SMBUtil.readInt8(buffer, bufferIndex);
         bufferIndex += 8;
+
+        if ( log.isTraceEnabled() ) {
+            log.trace(String.format("SMB2 Header: mid=%d, command=%d, creditCharge=%d, creditGranted=%d, status=0x%08x, flags=0x%08x", 
+                this.mid, this.command, this.creditCharge, this.credit, this.status, this.flags));
+        }
 
         if ( ( this.flags & SMB2_FLAGS_ASYNC_COMMAND ) == SMB2_FLAGS_ASYNC_COMMAND ) {
             // async

--- a/src/main/java/jcifs/internal/smb2/io/Smb2ReadRequest.java
+++ b/src/main/java/jcifs/internal/smb2/io/Smb2ReadRequest.java
@@ -81,6 +81,15 @@ public class Smb2ReadRequest extends ServerMessageBlock2Request<Smb2ReadResponse
     }
 
 
+    @Override
+    public int getCreditCost () {
+        if ( this.readLength <= 0 ) {
+            return 1;
+        }
+        return ( this.readLength - 1 ) / 65536 + 1;
+    }
+
+
     /**
      * {@inheritDoc}
      *
@@ -190,6 +199,14 @@ public class Smb2ReadRequest extends ServerMessageBlock2Request<Smb2ReadResponse
         // one byte in buffer must be zero
         dst[ dstIndex ] = 0;
         dstIndex += 1;
+
+        // pad to 8 byte boundary to match size()
+        int total = dstIndex - start + Smb2Constants.SMB2_HEADER_LENGTH;
+        int aligned = size8(total);
+        int pad = aligned - total;
+        for ( int i = 0; i < pad; i++ ) {
+            dst[ dstIndex++ ] = (byte) 0;
+        }
 
         return dstIndex - start;
     }

--- a/src/main/java/jcifs/internal/smb2/io/Smb2WriteRequest.java
+++ b/src/main/java/jcifs/internal/smb2/io/Smb2WriteRequest.java
@@ -75,6 +75,15 @@ public class Smb2WriteRequest extends ServerMessageBlock2Request<Smb2WriteRespon
     }
 
 
+    @Override
+    public int getCreditCost () {
+        if ( this.dataLength <= 0 ) {
+            return 1;
+        }
+        return ( this.dataLength - 1 ) / 65536 + 1;
+    }
+
+
     /**
      * @param data
      *            the data to set
@@ -164,6 +173,15 @@ public class Smb2WriteRequest extends ServerMessageBlock2Request<Smb2WriteRespon
 
         System.arraycopy(this.data, this.dataOffset, dst, dstIndex, this.dataLength);
         dstIndex += this.dataLength;
+
+        /* pad to 8 byte boundary to match size() */
+        int total = dstIndex - start + Smb2Constants.SMB2_HEADER_LENGTH;
+        int aligned = size8(total);
+        int pad = aligned - total;
+        for ( int i = 0; i < pad; i++ ) {
+            dst[ dstIndex++ ] = (byte) 0;
+        }
+
         return dstIndex - start;
     }
 

--- a/src/main/java/jcifs/internal/smb2/nego/Smb2NegotiateRequest.java
+++ b/src/main/java/jcifs/internal/smb2/nego/Smb2NegotiateRequest.java
@@ -61,6 +61,10 @@ public class Smb2NegotiateRequest extends ServerMessageBlock2Request<Smb2Negotia
             this.capabilities |= Smb2Constants.SMB2_GLOBAL_CAP_ENCRYPTION;
         }
 
+        if ( config.getMaximumVersion() != null && config.getMaximumVersion().atLeast(DialectVersion.SMB210) ) {
+            this.capabilities |= Smb2Constants.SMB2_GLOBAL_CAP_LARGE_MTU;
+        }
+
         Set<DialectVersion> dvs = DialectVersion
                 .range(DialectVersion.max(DialectVersion.SMB202, config.getMinimumVersion()), config.getMaximumVersion());
 

--- a/src/main/java/jcifs/internal/smb2/nego/Smb2NegotiateResponse.java
+++ b/src/main/java/jcifs/internal/smb2/nego/Smb2NegotiateResponse.java
@@ -307,8 +307,8 @@ public class Smb2NegotiateResponse extends ServerMessageBlock2Response implement
             this.maxTransactSize = Math.min(maxBufferSize - 512, this.maxTransactSize) & ~0x7;
         }
 
-        if ( log.isInfoEnabled() ) {
-            log.info(String.format("Negotiated maxReadSize=%d, maxWriteSize=%d, maxTransactSize=%d", this.maxReadSize, this.maxWriteSize, this.maxTransactSize));
+        if ( log.isDebugEnabled() ) {
+            log.debug(String.format("Negotiated maxReadSize=%d, maxWriteSize=%d, maxTransactSize=%d", this.maxReadSize, this.maxWriteSize, this.maxTransactSize));
         }
 
         return true;

--- a/src/main/java/jcifs/internal/smb2/nego/Smb2NegotiateResponse.java
+++ b/src/main/java/jcifs/internal/smb2/nego/Smb2NegotiateResponse.java
@@ -294,11 +294,22 @@ public class Smb2NegotiateResponse extends ServerMessageBlock2Response implement
         }
 
         int maxBufferSize = tc.getConfig().getTransactionBufferSize();
-        this.maxReadSize = Math.min(maxBufferSize - Smb2ReadResponse.OVERHEAD, Math.min(tc.getConfig().getReceiveBufferSize(), this.maxReadSize))
-                & ~0x7;
-        this.maxWriteSize = Math.min(maxBufferSize - Smb2WriteRequest.OVERHEAD, Math.min(tc.getConfig().getSendBufferSize(), this.maxWriteSize))
-                & ~0x7;
-        this.maxTransactSize = Math.min(maxBufferSize - 512, this.maxTransactSize) & ~0x7;
+        if ( this.selectedDialect.atLeast(DialectVersion.SMB210) && ( this.commonCapabilities & Smb2Constants.SMB2_GLOBAL_CAP_LARGE_MTU ) != 0 ) {
+            this.maxReadSize = Math.min(tc.getConfig().getReceiveBufferSize(), this.maxReadSize) & ~0x7;
+            this.maxWriteSize = Math.min(tc.getConfig().getSendBufferSize(), this.maxWriteSize) & ~0x7;
+            this.maxTransactSize = Math.min(maxBufferSize - 512, this.maxTransactSize) & ~0x7;
+        }
+        else {
+            this.maxReadSize = Math.min(maxBufferSize - Smb2ReadResponse.OVERHEAD, Math.min(tc.getConfig().getReceiveBufferSize(), this.maxReadSize))
+                    & ~0x7;
+            this.maxWriteSize = Math.min(maxBufferSize - Smb2WriteRequest.OVERHEAD, Math.min(tc.getConfig().getSendBufferSize(), this.maxWriteSize))
+                    & ~0x7;
+            this.maxTransactSize = Math.min(maxBufferSize - 512, this.maxTransactSize) & ~0x7;
+        }
+
+        if ( log.isInfoEnabled() ) {
+            log.info(String.format("Negotiated maxReadSize=%d, maxWriteSize=%d, maxTransactSize=%d", this.maxReadSize, this.maxWriteSize, this.maxTransactSize));
+        }
 
         return true;
     }

--- a/src/main/java/jcifs/smb/BufferCacheImpl.java
+++ b/src/main/java/jcifs/smb/BufferCacheImpl.java
@@ -82,12 +82,6 @@ public class BufferCacheImpl implements BufferCache {
     }
 
 
-    /**
-     * {@inheritDoc}
-     *
-     * @see jcifs.BufferCache#getMaximumBufferSize()
-     */
-    @Override
     public int getMaximumBufferSize () {
         return this.bufferSize;
     }

--- a/src/main/java/jcifs/smb/BufferCacheImpl.java
+++ b/src/main/java/jcifs/smb/BufferCacheImpl.java
@@ -85,6 +85,17 @@ public class BufferCacheImpl implements BufferCache {
     /**
      * {@inheritDoc}
      *
+     * @see jcifs.BufferCache#getMaximumBufferSize()
+     */
+    @Override
+    public int getMaximumBufferSize () {
+        return this.bufferSize;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     *
      * @see jcifs.BufferCache#releaseBuffer(byte[])
      */
     @Override

--- a/src/main/java/jcifs/smb/BufferCacheImpl.java
+++ b/src/main/java/jcifs/smb/BufferCacheImpl.java
@@ -81,12 +81,6 @@ public class BufferCacheImpl implements BufferCache {
         }
     }
 
-
-    public int getMaximumBufferSize () {
-        return this.bufferSize;
-    }
-
-
     /**
      * {@inheritDoc}
      *

--- a/src/main/java/jcifs/smb/SmbFileOutputStream.java
+++ b/src/main/java/jcifs/smb/SmbFileOutputStream.java
@@ -327,6 +327,7 @@ public class SmbFileOutputStream extends OutputStream {
                 if ( this.smb2 ) {
                     Smb2WriteRequest wr = new Smb2WriteRequest(th.getConfig(), fh.getFileId());
                     wr.setOffset(this.fp);
+                    wr.setRemainingBytes(len - w);
                     wr.setData(b, off, w);
 
                     Smb2WriteResponse resp = th.send(wr, RequestParam.NO_RETRY);

--- a/src/main/java/jcifs/smb/SmbTransportImpl.java
+++ b/src/main/java/jcifs/smb/SmbTransportImpl.java
@@ -1049,10 +1049,10 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
             CommonServerMessageBlockRequest thisReq = curHead;
             try {
                 CommonServerMessageBlockResponse resp = thisReq.getResponse();
-                if ( log.isInfoEnabled() ) {
+                if ( log.isDebugEnabled() ) {
                     if ( thisReq instanceof ServerMessageBlock2 ) {
                         ServerMessageBlock2 smb2Req = (ServerMessageBlock2) thisReq;
-                        log.info(String.format("Sending %s (mid=%d, cost=%d, credits_avail=%d, reqCredits=%d, charge=%d)",
+                        log.debug(String.format("Sending %s (mid=%d, cost=%d, credits_avail=%d, reqCredits=%d, charge=%d)",
                             thisReq.getClass().getSimpleName(),
                             thisReq.getMid(),
                             totalCost,
@@ -1061,7 +1061,7 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
                             smb2Req.getCreditCharge()));
                     }
                     else {
-                        log.info(String.format("Sending %s (mid=%d, cost=%d, credits_avail=%d)",
+                        log.debug(String.format("Sending %s (mid=%d, cost=%d, credits_avail=%d)",
                             thisReq.getClass().getSimpleName(), thisReq.getMid(), totalCost, this.credits.availablePermits()));
                     }
                 }

--- a/src/main/java/jcifs/smb/SmbTransportImpl.java
+++ b/src/main/java/jcifs/smb/SmbTransportImpl.java
@@ -916,50 +916,34 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
 
         CommonServerMessageBlock smb = (CommonServerMessageBlock) request;
         int size = ( (CommonServerMessageBlockRequest) request ).size();
-        byte[] buffer = null;
-        boolean fromCache = false;
         int maximumBufferSize = getContext().getConfig().getMaximumBufferSize();
+        int bsize = Math.max(size + 4, maximumBufferSize);
+        byte[] buffer = new byte[bsize];
 
-        if ( size > 0 && size + 4 <= maximumBufferSize ) {
-            buffer = getContext().getBufferCache().getBuffer();
-            fromCache = true;
-        }
+        // synchronize around encode and write so that the ordering for SMB1 signing can be maintained
+        synchronized ( this.outLock ) {
+            int n = smb.encode(buffer, 4);
+            buffer[ 0 ] = (byte) 0x00;
+            buffer[ 1 ] = (byte) ( ( n >> 16 ) & 0xFF );
+            buffer[ 2 ] = (byte) ( ( n >> 8 ) & 0xFF );
+            buffer[ 3 ] = (byte) ( n & 0xFF );
 
-        if ( buffer == null ) {
-            int bsize = Math.max(size + 4, maximumBufferSize);
-            buffer = new byte[bsize];
-        }
-
-        try {
-            // synchronize around encode and write so that the ordering for SMB1 signing can be maintained
-            synchronized ( this.outLock ) {
-                int n = smb.encode(buffer, 4);
-                buffer[ 0 ] = (byte) 0x00;
-                buffer[ 1 ] = (byte) ( ( n >> 16 ) & 0xFF );
-                buffer[ 2 ] = (byte) ( ( n >> 8 ) & 0xFF );
-                buffer[ 3 ] = (byte) ( n & 0xFF );
-
-                if ( log.isTraceEnabled() ) {
-                    do {
-                        log.trace(smb.toString());
-                    }
-                    while ( smb instanceof AndXServerMessageBlock && ( smb = ( (AndXServerMessageBlock) smb ).getAndx() ) != null );
-                    log.trace(Hexdump.toHexString(buffer, 4, n));
-
+            if ( log.isTraceEnabled() ) {
+                do {
+                    log.trace(smb.toString());
                 }
-                /*
-                 * For some reason this can sometimes get broken up into another
-                 * "NBSS Continuation Message" frame according to WireShark
-                 */
+                while ( smb instanceof AndXServerMessageBlock && ( smb = ( (AndXServerMessageBlock) smb ).getAndx() ) != null );
+                log.trace(Hexdump.toHexString(buffer, 4, n));
 
-                this.out.write(buffer, 0, 4 + n);
-                this.out.flush();
             }
-        }
-        finally {
-            if ( fromCache ) {
-                this.getContext().getBufferCache().releaseBuffer(buffer);
-            }
+
+            /*
+             * For some reason this can sometimes get broken up into another
+             * "NBSS Continuation Message" frame according to WireShark
+             */
+
+            this.out.write(buffer, 0, 4 + n);
+            this.out.flush();
         }
     }
 
@@ -1274,38 +1258,62 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
         int nextCommand = Encdec.dec_uint32le(this.sbuf, 4 + 20);
         int maximumBufferSize = getContext().getConfig().getMaximumBufferSize();
         int msgSize = nextCommand != 0 ? nextCommand : size;
-        
+
         ServerMessageBlock2Response cur = (ServerMessageBlock2Response) response;
-        byte[] buffer = null;
-        boolean fromCache = false;
-        
-        if ( this.largeMtu ) {
-            if ( msgSize + 4 <= maximumBufferSize ) {
-                buffer = getContext().getBufferCache().getBuffer();
-                fromCache = true;
-            }
-            else {
-                buffer = new byte[msgSize + 4];
-            }
-        }
-        else {
-            if ( msgSize > maximumBufferSize ) {
-                throw new IOException(String.format("Message size %d exceeds maxiumum buffer size %d", msgSize, maximumBufferSize));
-            }
-            buffer = getContext().getBufferCache().getBuffer();
-            fromCache = true;
+        if ( !this.largeMtu && msgSize > maximumBufferSize ) {
+            throw new IOException(String.format("Message size %d exceeds maxiumum buffer size %d", msgSize, maximumBufferSize));
         }
 
-        try {
-            int rl = nextCommand != 0 ? nextCommand : size;
+        byte[] buffer = new byte[msgSize];
 
-            // read and decode first
-            System.arraycopy(this.sbuf, 4, buffer, 0, Smb2Constants.SMB2_HEADER_LENGTH);
-            readn(this.in, buffer, Smb2Constants.SMB2_HEADER_LENGTH, rl - Smb2Constants.SMB2_HEADER_LENGTH);
+        int rl = nextCommand != 0 ? nextCommand : size;
+
+        // read and decode first
+        System.arraycopy(this.sbuf, 4, buffer, 0, Smb2Constants.SMB2_HEADER_LENGTH);
+        readn(this.in, buffer, Smb2Constants.SMB2_HEADER_LENGTH, rl - Smb2Constants.SMB2_HEADER_LENGTH);
+
+        cur.setReadSize(rl);
+        int len = cur.decode(buffer, 0);
+
+        if ( len > rl ) {
+            throw new IOException(String.format("WHAT? ( read %d decoded %d ): %s", rl, len, cur));
+        }
+        else if ( nextCommand != 0 && len > nextCommand ) {
+            throw new IOException("Overlapping commands");
+        }
+        size -= rl;
+
+        while ( size > 0 && nextCommand != 0 ) {
+            cur = (ServerMessageBlock2Response) cur.getNextResponse();
+            if ( cur == null ) {
+                log.warn("Response not properly set up");
+                this.in.skip(size);
+                break;
+            }
+
+            // read next header
+            readn(this.in, buffer, 0, Smb2Constants.SMB2_HEADER_LENGTH);
+            nextCommand = Encdec.dec_uint32le(buffer, 20);
+
+            rl = nextCommand != 0 ? nextCommand : size;
+            if ( !this.largeMtu && rl > maximumBufferSize ) {
+                throw new IOException(String.format("Message size %d exceeds maxiumum buffer size %d", rl, maximumBufferSize));
+            }
+
+            if ( rl > buffer.length ) {
+                byte[] newBuffer = new byte[rl];
+                System.arraycopy(buffer, 0, newBuffer, 0, Smb2Constants.SMB2_HEADER_LENGTH);
+                buffer = newBuffer;
+            }
+
+            if ( log.isDebugEnabled() ) {
+                log.debug(String.format("Compound next command %d read size %d remain %d", nextCommand, rl, size));
+            }
 
             cur.setReadSize(rl);
-            int len = cur.decode(buffer, 0);
+            readn(this.in, buffer, Smb2Constants.SMB2_HEADER_LENGTH, rl - Smb2Constants.SMB2_HEADER_LENGTH);
 
+            len = cur.decode(buffer, 0, true);
             if ( len > rl ) {
                 throw new IOException(String.format("WHAT? ( read %d decoded %d ): %s", rl, len, cur));
             }
@@ -1313,55 +1321,6 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
                 throw new IOException("Overlapping commands");
             }
             size -= rl;
-
-            while ( size > 0 && nextCommand != 0 ) {
-                cur = (ServerMessageBlock2Response) cur.getNextResponse();
-                if ( cur == null ) {
-                    log.warn("Response not properly set up");
-                    this.in.skip(size);
-                    break;
-                }
-
-                // read next header
-                readn(this.in, buffer, 0, Smb2Constants.SMB2_HEADER_LENGTH);
-                nextCommand = Encdec.dec_uint32le(buffer, 20);
-
-                rl = nextCommand != 0 ? nextCommand : size;
-                if ( !this.largeMtu && rl > maximumBufferSize ) {
-                    throw new IOException(String.format("Message size %d exceeds maxiumum buffer size %d", rl, maximumBufferSize));
-                }
-
-                if ( rl > buffer.length ) {
-                    byte[] newBuffer = new byte[rl];
-                    System.arraycopy(buffer, 0, newBuffer, 0, Smb2Constants.SMB2_HEADER_LENGTH);
-                    if ( fromCache ) {
-                        getContext().getBufferCache().releaseBuffer(buffer);
-                        fromCache = false;
-                    }
-                    buffer = newBuffer;
-                }
-
-                if ( log.isDebugEnabled() ) {
-                    log.debug(String.format("Compound next command %d read size %d remain %d", nextCommand, rl, size));
-                }
-
-                cur.setReadSize(rl);
-                readn(this.in, buffer, Smb2Constants.SMB2_HEADER_LENGTH, rl - Smb2Constants.SMB2_HEADER_LENGTH);
-
-                len = cur.decode(buffer, 0, true);
-                if ( len > rl ) {
-                    throw new IOException(String.format("WHAT? ( read %d decoded %d ): %s", rl, len, cur));
-                }
-                else if ( nextCommand != 0 && len > nextCommand ) {
-                    throw new IOException("Overlapping commands");
-                }
-                size -= rl;
-            }
-        }
-        finally {
-            if ( fromCache && buffer != null ) {
-                getContext().getBufferCache().releaseBuffer(buffer);
-            }
         }
     }
 

--- a/src/main/java/jcifs/smb/SmbTransportImpl.java
+++ b/src/main/java/jcifs/smb/SmbTransportImpl.java
@@ -916,9 +916,7 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
 
         CommonServerMessageBlock smb = (CommonServerMessageBlock) request;
         int size = ( (CommonServerMessageBlockRequest) request ).size();
-        int maximumBufferSize = getContext().getConfig().getMaximumBufferSize();
-        int bsize = Math.max(size + 4, maximumBufferSize);
-        byte[] buffer = new byte[bsize];
+        byte[] buffer = new byte[size + 4];
 
         // synchronize around encode and write so that the ordering for SMB1 signing can be maintained
         synchronized ( this.outLock ) {

--- a/src/main/java/jcifs/smb/SmbTransportImpl.java
+++ b/src/main/java/jcifs/smb/SmbTransportImpl.java
@@ -915,17 +915,18 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
     protected void doSend ( Request request ) throws IOException {
 
         CommonServerMessageBlock smb = (CommonServerMessageBlock) request;
-        int size = request.size();
+        int size = ( (CommonServerMessageBlockRequest) request ).size();
         byte[] buffer = null;
         boolean fromCache = false;
+        int maximumBufferSize = getContext().getConfig().getMaximumBufferSize();
 
-        if ( size > 0 && size + 4 <= getContext().getBufferCache().getMaximumBufferSize() ) {
+        if ( size > 0 && size + 4 <= maximumBufferSize ) {
             buffer = getContext().getBufferCache().getBuffer();
             fromCache = true;
         }
 
         if ( buffer == null ) {
-            int bsize = Math.max(size + 4, getContext().getBufferCache().getMaximumBufferSize());
+            int bsize = Math.max(size + 4, maximumBufferSize);
             buffer = new byte[bsize];
         }
 
@@ -993,7 +994,9 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
                 }
                 if ( ( next == null || chain.allowChain(next) ) && totalSize + size < maxSize && this.credits.tryAcquire(cost) ) {
                     if ( this.largeMtu && cost > 1 ) {
-                        chain.setCreditCharge(cost);
+                        if ( chain instanceof ServerMessageBlock2 ) {
+                            ( (ServerMessageBlock2) chain ).setCreditCharge(cost);
+                        }
                     }
                     totalSize += size;
                     totalCost += cost;
@@ -1018,7 +1021,9 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
                             }
                         }
                         if ( this.largeMtu && cost > 1 ) {
-                            chain.setCreditCharge(cost);
+                            if ( chain instanceof ServerMessageBlock2 ) {
+                                ( (ServerMessageBlock2) chain ).setCreditCharge(cost);
+                            }
                         }
                         totalSize += size;
                         totalCost += cost;

--- a/src/main/java/jcifs/smb/SmbTransportImpl.java
+++ b/src/main/java/jcifs/smb/SmbTransportImpl.java
@@ -126,6 +126,9 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
     private final boolean signingEnforced;
 
     private SmbNegotiationResponse negotiated;
+    private DialectVersion selectedDialect;
+    private boolean largeMtu;
+    private int lastSize;
 
     private SMBSigningDigest digest;
 
@@ -740,7 +743,9 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
         /* Adjust negotiated values */
         this.tconHostName = this.address.getHostName();
         this.negotiated = resp.getResponse();
-        if ( resp.getResponse().getSelectedDialect().atLeast(DialectVersion.SMB311) ) {
+        this.selectedDialect = this.negotiated.getSelectedDialect();
+        this.largeMtu = this.selectedDialect.atLeast(DialectVersion.SMB210) && this.negotiated.haveCapabilitiy(Smb2Constants.SMB2_GLOBAL_CAP_LARGE_MTU);
+        if ( this.selectedDialect.atLeast(DialectVersion.SMB311) ) {
             updatePreauthHash(resp.getRequestRaw());
             updatePreauthHash(resp.getResponseRaw());
             if ( log.isDebugEnabled() ) {
@@ -813,8 +818,13 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
 
     @Override
     protected long makeKey ( Request request ) throws IOException {
-        long m = this.mid.incrementAndGet() - 1;
-        if ( !this.smb2 ) {
+        long m;
+        if ( this.smb2 ) {
+            int cost = Math.max(1, request.getCreditCost());
+            m = this.mid.getAndAdd(cost);
+        }
+        else {
+            m = this.mid.incrementAndGet() - 1;
             m = ( m % 32000 );
         }
         ( (CommonServerMessageBlock) request ).setMid(m);
@@ -826,13 +836,40 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
     protected Long peekKey () throws IOException {
         do {
             if ( ( readn(this.in, this.sbuf, 0, 4) ) < 4 ) {
+                if ( log.isDebugEnabled() )
+                    log.debug("Failed to read NBSS header");
                 return null;
             }
         }
         while ( this.sbuf[ 0 ] == (byte) 0x85 ); /* Dodge NetBIOS keep-alive */
+
+        this.lastSize = ( ( this.sbuf[ 1 ] & 0xFF ) << 16 ) | ( ( this.sbuf[ 2 ] & 0xFF ) << 8 ) | ( this.sbuf[ 3 ] & 0xFF );
+        if ( log.isTraceEnabled() ) {
+            log.trace("NBSS message size " + this.lastSize);
+        }
+
         /* read smb header */
         if ( ( readn(this.in, this.sbuf, 4, SmbConstants.SMB1_HEADER_LENGTH) ) < SmbConstants.SMB1_HEADER_LENGTH ) {
+            if ( log.isDebugEnabled() )
+                log.debug("Failed to read SMB1 header part");
             return null;
+        }
+
+        if ( this.sbuf[ 4 ] == (byte) 0xFE && this.sbuf[ 5 ] == (byte) 'S' && this.sbuf[ 6 ] == (byte) 'M' && this.sbuf[ 7 ] == (byte) 'B' ) {
+            this.smb2 = true;
+            this.lastSize = ( ( this.sbuf[ 1 ] & 0xFF ) << 16 ) | ( ( this.sbuf[ 2 ] & 0xFF ) << 8 ) | ( this.sbuf[ 3 ] & 0xFF );
+            /* also read the rest of the header */
+            int lenDiff = Smb2Constants.SMB2_HEADER_LENGTH - SmbConstants.SMB1_HEADER_LENGTH;
+            if ( readn(this.in, this.sbuf, 4 + SmbConstants.SMB1_HEADER_LENGTH, lenDiff) < lenDiff ) {
+                if ( log.isDebugEnabled() )
+                    log.debug("Failed to read SMB2 header part");
+                return null;
+            }
+            long mid = (long) Encdec.dec_uint64le(this.sbuf, 28);
+            if ( log.isTraceEnabled() ) {
+                log.trace("SMB2 message mid " + mid + " size " + this.lastSize);
+            }
+            return mid;
         }
 
         if ( log.isTraceEnabled() ) {
@@ -841,40 +878,26 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
         }
 
         for ( ;; ) {
-            /*
-             * 01234567
-             * 00SSFSMB
-             * 0 - 0's
-             * S - size of payload
-             * FSMB - 0xFF SMB magic #
-             */
 
-            if ( this.sbuf[ 0 ] == (byte) 0x00 && this.sbuf[ 4 ] == (byte) 0xFE && this.sbuf[ 5 ] == (byte) 'S' && this.sbuf[ 6 ] == (byte) 'M'
+            if ( this.sbuf[ 0 ] == (byte) 0x00 && this.sbuf[ 4 ] == (byte) 0xFF && this.sbuf[ 5 ] == (byte) 'S' && this.sbuf[ 6 ] == (byte) 'M'
                     && this.sbuf[ 7 ] == (byte) 'B' ) {
-                this.smb2 = true;
-                // also read the rest of the header
-                int lenDiff = Smb2Constants.SMB2_HEADER_LENGTH - SmbConstants.SMB1_HEADER_LENGTH;
-                if ( readn(this.in, this.sbuf, 4 + SmbConstants.SMB1_HEADER_LENGTH, lenDiff) < lenDiff ) {
-                    return null;
-                }
-                return (long) Encdec.dec_uint64le(this.sbuf, 28);
-            }
-
-            if ( this.sbuf[ 0 ] == (byte) 0x00 && this.sbuf[ 1 ] == (byte) 0x00 && ( this.sbuf[ 4 ] == (byte) 0xFF ) && this.sbuf[ 5 ] == (byte) 'S'
-                    && this.sbuf[ 6 ] == (byte) 'M' && this.sbuf[ 7 ] == (byte) 'B' ) {
+                this.lastSize = ( ( this.sbuf[ 1 ] & 0xFF ) << 16 ) | ( ( this.sbuf[ 2 ] & 0xFF ) << 8 ) | ( this.sbuf[ 3 ] & 0xFF );
                 break; /* all good (SMB) */
             }
 
             /* out of phase maybe? */
             /* inch forward 1 byte and try again */
+            log.warn("Possibly out of phase, trying to resync " + Hexdump.toHexString(this.sbuf, 0, 16));
             for ( int i = 0; i < 35; i++ ) {
-                log.warn("Possibly out of phase, trying to resync " + Hexdump.toHexString(this.sbuf, 0, 16));
                 this.sbuf[ i ] = this.sbuf[ i + 1 ];
             }
             int b;
             if ( ( b = this.in.read() ) == -1 )
                 return null;
             this.sbuf[ 35 ] = (byte) b;
+
+            /* re-evaluate lastSize if we are shifting */
+            this.lastSize = ( ( this.sbuf[ 1 ] & 0xFF ) << 16 ) | ( ( this.sbuf[ 2 ] & 0xFF ) << 8 ) | ( this.sbuf[ 3 ] & 0xFF );
         }
 
         /*
@@ -892,12 +915,29 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
     protected void doSend ( Request request ) throws IOException {
 
         CommonServerMessageBlock smb = (CommonServerMessageBlock) request;
-        byte[] buffer = this.getContext().getBufferCache().getBuffer();
+        int size = request.size();
+        byte[] buffer = null;
+        boolean fromCache = false;
+
+        if ( size > 0 && size + 4 <= getContext().getBufferCache().getMaximumBufferSize() ) {
+            buffer = getContext().getBufferCache().getBuffer();
+            fromCache = true;
+        }
+
+        if ( buffer == null ) {
+            int bsize = Math.max(size + 4, getContext().getBufferCache().getMaximumBufferSize());
+            buffer = new byte[bsize];
+        }
+
         try {
             // synchronize around encode and write so that the ordering for SMB1 signing can be maintained
             synchronized ( this.outLock ) {
                 int n = smb.encode(buffer, 4);
-                Encdec.enc_uint32be(n & 0xFFFF, buffer, 0); /* 4 byte session message header */
+                buffer[ 0 ] = (byte) 0x00;
+                buffer[ 1 ] = (byte) ( ( n >> 16 ) & 0xFF );
+                buffer[ 2 ] = (byte) ( ( n >> 8 ) & 0xFF );
+                buffer[ 3 ] = (byte) ( n & 0xFF );
+
                 if ( log.isTraceEnabled() ) {
                     do {
                         log.trace(smb.toString());
@@ -916,7 +956,9 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
             }
         }
         finally {
-            this.getContext().getBufferCache().releaseBuffer(buffer);
+            if ( fromCache ) {
+                this.getContext().getBufferCache().releaseBuffer(buffer);
+            }
         }
     }
 
@@ -929,10 +971,14 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
         CommonServerMessageBlockRequest curHead = request;
 
         int maxSize = getContext().getConfig().getMaximumBufferSize();
+        if ( this.largeMtu ) {
+            maxSize = Math.max(maxSize, 16 * 1024 * 1024);
+        }
 
         while ( curHead != null ) {
             CommonServerMessageBlockRequest nextHead = null;
             int totalSize = 0;
+            int totalCost = 0;
             int n = 0;
             CommonServerMessageBlockRequest last = null;
             CommonServerMessageBlockRequest chain = curHead;
@@ -946,7 +992,11 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
                         String.format("%s costs %d avail %d (%s)", chain.getClass().getName(), cost, this.credits.availablePermits(), this.name));
                 }
                 if ( ( next == null || chain.allowChain(next) ) && totalSize + size < maxSize && this.credits.tryAcquire(cost) ) {
+                    if ( this.largeMtu && cost > 1 ) {
+                        chain.setCreditCharge(cost);
+                    }
                     totalSize += size;
+                    totalCost += cost;
                     last = chain;
                     chain = next;
                 }
@@ -967,7 +1017,11 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
                                 throw new SmbException("Failed to acquire credits in time");
                             }
                         }
+                        if ( this.largeMtu && cost > 1 ) {
+                            chain.setCreditCharge(cost);
+                        }
                         totalSize += size;
+                        totalCost += cost;
                         // split off first request
 
                         synchronized ( chain ) {
@@ -997,17 +1051,30 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
                 }
             }
 
-            int reqCredits = Math.max(1, this.desiredCredits - this.credits.availablePermits() - n + 1);
+            int reqCredits = Math.max(totalCost, this.desiredCredits - this.credits.availablePermits() - n + 1);
             if ( log.isTraceEnabled() ) {
                 log.trace("Request credits " + reqCredits);
             }
-            request.setRequestCredits(reqCredits);
+            curHead.setRequestCredits(reqCredits);
 
             CommonServerMessageBlockRequest thisReq = curHead;
             try {
                 CommonServerMessageBlockResponse resp = thisReq.getResponse();
-                if ( log.isTraceEnabled() ) {
-                    log.trace("Sending " + thisReq);
+                if ( log.isInfoEnabled() ) {
+                    if ( thisReq instanceof ServerMessageBlock2 ) {
+                        ServerMessageBlock2 smb2Req = (ServerMessageBlock2) thisReq;
+                        log.info(String.format("Sending %s (mid=%d, cost=%d, credits_avail=%d, reqCredits=%d, charge=%d)",
+                            thisReq.getClass().getSimpleName(),
+                            thisReq.getMid(),
+                            totalCost,
+                            this.credits.availablePermits(),
+                            smb2Req.getCredit(),
+                            smb2Req.getCreditCharge()));
+                    }
+                    else {
+                        log.info(String.format("Sending %s (mid=%d, cost=%d, credits_avail=%d)",
+                            thisReq.getClass().getSimpleName(), thisReq.getMid(), totalCost, this.credits.availablePermits()));
+                    }
                 }
                 resp = super.sendrecv(curHead, resp, params);
 
@@ -1048,20 +1115,12 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
                     }
                     curReq = next;
                 }
-                if ( !isDisconnected() && !curReq.isResponseAsync() && !curReq.getResponse().isAsync() && !curReq.getResponse().isError()
-                        && grantedCredits == 0 ) {
-                    if ( this.credits.availablePermits() > 0 || n > 0 ) {
-                        log.debug("Server " + this + " returned zero credits for " + curReq);
-                    }
-                    else {
-                        log.warn("Server " + this + " took away all our credits");
-                    }
-                }
-                else if ( !curReq.isResponseAsync() ) {
+                if ( !isDisconnected() && !curReq.isResponseAsync() ) {
+                    int toRelease = Math.max(grantedCredits, totalCost);
                     if ( log.isTraceEnabled() ) {
-                        log.trace("Adding credits " + grantedCredits);
+                        log.trace("Adding credits " + toRelease + " (granted " + grantedCredits + " cost " + totalCost + ")");
                     }
-                    this.credits.release(grantedCredits);
+                    this.credits.release(toRelease);
                 }
             }
         }
@@ -1197,7 +1256,7 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
      * @throws SMBProtocolDecodingException
      */
     private void doRecvSMB2 ( CommonServerMessageBlock response ) throws IOException, SMBProtocolDecodingException {
-        int size = ( Encdec.dec_uint16be(this.sbuf, 2) & 0xFFFF ) | ( this.sbuf[ 1 ] & 0xFF ) << 16;
+        int size = this.lastSize;
         if ( size < ( Smb2Constants.SMB2_HEADER_LENGTH + 1 ) ) {
             throw new IOException("Invalid payload size: " + size);
         }
@@ -1210,12 +1269,28 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
         int nextCommand = Encdec.dec_uint32le(this.sbuf, 4 + 20);
         int maximumBufferSize = getContext().getConfig().getMaximumBufferSize();
         int msgSize = nextCommand != 0 ? nextCommand : size;
-        if ( msgSize > maximumBufferSize ) {
-            throw new IOException(String.format("Message size %d exceeds maxiumum buffer size %d", msgSize, maximumBufferSize));
+        
+        ServerMessageBlock2Response cur = (ServerMessageBlock2Response) response;
+        byte[] buffer = null;
+        boolean fromCache = false;
+        
+        if ( this.largeMtu ) {
+            if ( msgSize + 4 <= maximumBufferSize ) {
+                buffer = getContext().getBufferCache().getBuffer();
+                fromCache = true;
+            }
+            else {
+                buffer = new byte[msgSize + 4];
+            }
+        }
+        else {
+            if ( msgSize > maximumBufferSize ) {
+                throw new IOException(String.format("Message size %d exceeds maxiumum buffer size %d", msgSize, maximumBufferSize));
+            }
+            buffer = getContext().getBufferCache().getBuffer();
+            fromCache = true;
         }
 
-        ServerMessageBlock2Response cur = (ServerMessageBlock2Response) response;
-        byte[] buffer = getContext().getBufferCache().getBuffer();
         try {
             int rl = nextCommand != 0 ? nextCommand : size;
 
@@ -1246,12 +1321,20 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
                 readn(this.in, buffer, 0, Smb2Constants.SMB2_HEADER_LENGTH);
                 nextCommand = Encdec.dec_uint32le(buffer, 20);
 
-                if ( ( nextCommand != 0 && nextCommand > maximumBufferSize ) || ( nextCommand == 0 && size > maximumBufferSize ) ) {
-                    throw new IOException(
-                        String.format("Message size %d exceeds maxiumum buffer size %d", nextCommand != 0 ? nextCommand : size, maximumBufferSize));
+                rl = nextCommand != 0 ? nextCommand : size;
+                if ( !this.largeMtu && rl > maximumBufferSize ) {
+                    throw new IOException(String.format("Message size %d exceeds maxiumum buffer size %d", rl, maximumBufferSize));
                 }
 
-                rl = nextCommand != 0 ? nextCommand : size;
+                if ( rl > buffer.length ) {
+                    byte[] newBuffer = new byte[rl];
+                    System.arraycopy(buffer, 0, newBuffer, 0, Smb2Constants.SMB2_HEADER_LENGTH);
+                    if ( fromCache ) {
+                        getContext().getBufferCache().releaseBuffer(buffer);
+                        fromCache = false;
+                    }
+                    buffer = newBuffer;
+                }
 
                 if ( log.isDebugEnabled() ) {
                     log.debug(String.format("Compound next command %d read size %d remain %d", nextCommand, rl, size));
@@ -1271,7 +1354,9 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
             }
         }
         finally {
-            getContext().getBufferCache().releaseBuffer(buffer);
+            if ( fromCache && buffer != null ) {
+                getContext().getBufferCache().releaseBuffer(buffer);
+            }
         }
     }
 

--- a/src/main/java/jcifs/smb/SmbTransportImpl.java
+++ b/src/main/java/jcifs/smb/SmbTransportImpl.java
@@ -916,7 +916,9 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
 
         CommonServerMessageBlock smb = (CommonServerMessageBlock) request;
         int size = ( (CommonServerMessageBlockRequest) request ).size();
-        byte[] buffer = new byte[size + 4];
+        int maximumBufferSize = getContext().getConfig().getMaximumBufferSize();
+        int bsize = Math.max(size + 4, maximumBufferSize);
+        byte[] buffer = new byte[bsize];
 
         // synchronize around encode and write so that the ordering for SMB1 signing can be maintained
         synchronized ( this.outLock ) {

--- a/src/main/java/jcifs/util/Encdec.java
+++ b/src/main/java/jcifs/util/Encdec.java
@@ -70,6 +70,14 @@ public final class Encdec {
     }
 
 
+    public static int enc_uint24be ( int i, byte[] dst, int di ) {
+        dst[ di++ ] = (byte) ( ( i >> 16 ) & 0xFF );
+        dst[ di++ ] = (byte) ( ( i >> 8 ) & 0xFF );
+        dst[ di ] = (byte) ( i & 0xFF );
+        return 3;
+    }
+
+
     public static int enc_uint16le ( short s, byte[] dst, int di ) {
         dst[ di++ ] = (byte) ( s & 0xFF );
         dst[ di ] = (byte) ( ( s >> 8 ) & 0xFF );
@@ -97,6 +105,11 @@ public final class Encdec {
 
     public static int dec_uint32be ( byte[] src, int si ) {
         return ( ( src[ si ] & 0xFF ) << 24 ) | ( ( src[ si + 1 ] & 0xFF ) << 16 ) | ( ( src[ si + 2 ] & 0xFF ) << 8 ) | ( src[ si + 3 ] & 0xFF );
+    }
+
+
+    public static int dec_uint24be ( byte[] src, int si ) {
+        return ( ( src[ si ] & 0xFF ) << 16 ) | ( ( src[ si + 1 ] & 0xFF ) << 8 ) | ( src[ si + 2 ] & 0xFF );
     }
 
 

--- a/src/main/java/jcifs/util/transport/Request.java
+++ b/src/main/java/jcifs/util/transport/Request.java
@@ -31,19 +31,6 @@ public interface Request extends Message {
 
 
     /**
-     * @return the size of this request
-     */
-    int size ();
-
-
-    /**
-     * @param cost
-     */
-
-    void setCreditCharge ( int cost );
-
-
-    /**
      * @param credits
      */
     void setRequestCredits ( int credits );

--- a/src/main/java/jcifs/util/transport/Request.java
+++ b/src/main/java/jcifs/util/transport/Request.java
@@ -31,6 +31,19 @@ public interface Request extends Message {
 
 
     /**
+     * @return the size of this request
+     */
+    int size ();
+
+
+    /**
+     * @param cost
+     */
+
+    void setCreditCharge ( int cost );
+
+
+    /**
      * @param credits
      */
     void setRequestCredits ( int credits );

--- a/src/test/java/jcifs/tests/AllTests.java
+++ b/src/test/java/jcifs/tests/AllTests.java
@@ -56,7 +56,7 @@ import jcifs.context.BaseContext;
 @SuiteClasses ( {
     ContextConfigTest.class, PACTest.class, NtlmTest.class, FileLocationTest.class, SessionTest.class, KerberosTest.class, TimeoutTest.class,
     SidTest.class, NamingTest.class, DfsTest.class, FileAttributesTest.class, EnumTest.class, PipeTest.class, FileOperationsTest.class,
-    WatchTest.class, ReadWriteTest.class, ConcurrencyTest.class, RandomAccessFileTest.class, OplockTests.class
+    WatchTest.class, ReadWriteTest.class, ConcurrencyTest.class, RandomAccessFileTest.class, OplockTests.class, LargeFileTransferTest.class
 } )
 
 public class AllTests {

--- a/src/test/java/jcifs/tests/LargeFileTransferTest.java
+++ b/src/test/java/jcifs/tests/LargeFileTransferTest.java
@@ -1,0 +1,124 @@
+package jcifs.tests;
+
+import static org.junit.Assert.assertEquals;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import jcifs.smb.SmbFile;
+
+/**
+ * Test for large file transfers to verify multi-credit support and performance.
+ * Compares 64KB (Single-credit) vs 1MB (Multi-credit) transfers.
+ */
+@RunWith(Parameterized.class)
+public class LargeFileTransferTest extends BaseCIFSTest {
+
+    private static final Logger log = LoggerFactory.getLogger(LargeFileTransferTest.class);
+    private static final int FILE_SIZE = 64 * 1024 * 1024; // 64 MB
+    private final int transportBufferSize;
+
+    public LargeFileTransferTest(String name, Map<String, String> properties, int transportBufferSize) {
+        super(name, properties);
+        this.transportBufferSize = transportBufferSize;
+    }
+
+    @Parameters(name = "{0} - {2} bytes buffer")
+    public static Collection<Object> configs() {
+        List<Object> configs = new ArrayList<>();
+        String dialectFilter = System.getProperty("largeFileTransfer.dialects", "smb2,smb30,smb31");
+        String[] dialects = dialectFilter.split(",");
+        String filter = System.getProperty("largeFileTransfer.bufferSizes", "65536,1048576");
+        String[] parts = filter.split(",");
+        int[] bufferSizes = new int[parts.length];
+        for ( int i = 0; i < parts.length; i++ ) {
+            bufferSizes[ i ] = Integer.parseInt(parts[ i ].trim());
+        }
+
+        for (Object baseObj : getConfigs(dialects)) {
+
+            Object[] base = (Object[]) baseObj;
+            for (int bufSize : bufferSizes) {
+                configs.add(new Object[] { base[0] + "-" + bufSize, base[1], bufSize });
+            }
+        }
+        return configs;
+    }
+
+    @Override
+    @org.junit.Before
+    public void setUp() throws Exception {
+        if ( !getProperties().containsKey("jcifs.smb.client.maxVersion") ) {
+            getProperties().put("jcifs.smb.client.maxVersion", "SMB311");
+        }
+        if ( !getProperties().containsKey("jcifs.smb.client.minVersion") ) {
+            getProperties().put("jcifs.smb.client.minVersion", "SMB202");
+        }
+        getProperties().put("jcifs.smb.client.useSMB2Negotiation", "true");
+        getProperties().put("jcifs.smb.client.dfs.disabled", "true");
+        getProperties().put("jcifs.smb.client.ipcSigningEnforced", "false");
+        getProperties().put("jcifs.smb.client.disablePlainTextPasswords", "false");
+        getProperties().put("jcifs.smb.useRawNTLM", "true");
+        
+        // Set the transport buffer size for this run
+        getProperties().put("jcifs.smb.client.snd_buf_size", String.valueOf(transportBufferSize));
+        getProperties().put("jcifs.smb.client.rcv_buf_size", String.valueOf(transportBufferSize));
+        
+        super.setUp();
+    }
+
+    @Test
+    public void testLargeTransfer() throws IOException {
+        String mode = (transportBufferSize > 65536) ? "MULTI-CREDIT (1MB)" : "SINGLE-CREDIT (64KB)";
+        
+        try (SmbFile f = createTestFile()) {
+            log.info(">>> Mode: {} | Size: {} bytes | Target: {}", mode, FILE_SIZE, f.getURL());
+            
+            // Use a large application buffer to ensure we saturate the transport
+            byte[] data = new byte[1024 * 1024]; 
+            new Random().nextBytes(data);
+            
+            long startWrite = System.currentTimeMillis();
+            try (OutputStream os = f.getOutputStream()) {
+                int written = 0;
+                while (written < FILE_SIZE) {
+                    int toWrite = Math.min(data.length, FILE_SIZE - written);
+                    os.write(data, 0, toWrite);
+                    written += toWrite;
+                }
+            }
+            long endWrite = System.currentTimeMillis();
+            double writeTimeSec = (endWrite - startWrite) / 1000.0;
+            double writeSpeed = (FILE_SIZE / 1024.0 / 1024.0) / writeTimeSec;
+
+            long startRead = System.currentTimeMillis();
+            try (InputStream is = f.getInputStream()) {
+                byte[] readBuf = new byte[1024 * 1024];
+                long totalRead = 0;
+                int r;
+                while ((r = is.read(readBuf)) != -1) {
+                    totalRead += r;
+                }
+                assertEquals("Total bytes read should match", FILE_SIZE, totalRead);
+            }
+            long endRead = System.currentTimeMillis();
+            double readTimeSec = (endRead - startRead) / 1000.0;
+            double readSpeed = (FILE_SIZE / 1024.0 / 1024.0) / readTimeSec;
+
+            log.info("<<< Results ({}): Write: {} MB/s | Read: {} MB/s", mode, 
+                String.format("%.2f", writeSpeed), String.format("%.2f", readSpeed));
+            
+            f.delete();
+        }
+    }
+}

--- a/src/test/java/jcifs/tests/LargeFileTransferTest.java
+++ b/src/test/java/jcifs/tests/LargeFileTransferTest.java
@@ -1,3 +1,20 @@
+/*
+ * © 2025 Courville Software
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
 package jcifs.tests;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/jcifs/tests/LargeFileTransferTest.java
+++ b/src/test/java/jcifs/tests/LargeFileTransferTest.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -43,10 +45,20 @@ public class LargeFileTransferTest extends BaseCIFSTest {
 
     private static final Logger log = LoggerFactory.getLogger(LargeFileTransferTest.class);
     private static final int FILE_SIZE = 64 * 1024 * 1024; // 64 MB
+    private static final long DATA_SEED = 0x4A434946534C4E47L;
     private static final int[] BUFFER_SIZES = {
         65536, 1048576
     };
     private final int transportBufferSize;
+
+    private static MessageDigest newDigest() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        }
+        catch ( NoSuchAlgorithmException e ) {
+            throw new IllegalStateException("Missing SHA-256 support", e);
+        }
+    }
 
     public LargeFileTransferTest(String name, Map<String, String> properties, int transportBufferSize) {
         super(name, properties);
@@ -84,14 +96,17 @@ public class LargeFileTransferTest extends BaseCIFSTest {
             
             // Use a large application buffer to ensure we saturate the transport
             byte[] data = new byte[1024 * 1024]; 
-            new Random().nextBytes(data);
+            Random writeRandom = new Random(DATA_SEED);
+            MessageDigest expectedDigest = newDigest();
             
             long startWrite = System.currentTimeMillis();
             try (OutputStream os = f.getOutputStream()) {
                 int written = 0;
                 while (written < FILE_SIZE) {
                     int toWrite = Math.min(data.length, FILE_SIZE - written);
+                    writeRandom.nextBytes(data);
                     os.write(data, 0, toWrite);
+                    expectedDigest.update(data, 0, toWrite);
                     written += toWrite;
                 }
             }
@@ -102,12 +117,17 @@ public class LargeFileTransferTest extends BaseCIFSTest {
             long startRead = System.currentTimeMillis();
             try (InputStream is = f.getInputStream()) {
                 byte[] readBuf = new byte[1024 * 1024];
+                MessageDigest actualDigest = newDigest();
                 long totalRead = 0;
                 int r;
                 while ((r = is.read(readBuf)) != -1) {
+                    actualDigest.update(readBuf, 0, r);
                     totalRead += r;
                 }
                 assertEquals("Total bytes read should match", FILE_SIZE, totalRead);
+                assertEquals("Read digest should match written digest",
+                    toHex(expectedDigest.digest()),
+                    toHex(actualDigest.digest()));
             }
             long endRead = System.currentTimeMillis();
             double readTimeSec = (endRead - startRead) / 1000.0;
@@ -118,5 +138,13 @@ public class LargeFileTransferTest extends BaseCIFSTest {
             
             f.delete();
         }
+    }
+
+    private static String toHex(byte[] data) {
+        StringBuilder sb = new StringBuilder(data.length * 2);
+        for ( byte b : data ) {
+            sb.append(String.format("%02x", b & 0xff));
+        }
+        return sb.toString();
     }
 }

--- a/src/test/java/jcifs/tests/LargeFileTransferTest.java
+++ b/src/test/java/jcifs/tests/LargeFileTransferTest.java
@@ -43,6 +43,9 @@ public class LargeFileTransferTest extends BaseCIFSTest {
 
     private static final Logger log = LoggerFactory.getLogger(LargeFileTransferTest.class);
     private static final int FILE_SIZE = 64 * 1024 * 1024; // 64 MB
+    private static final int[] BUFFER_SIZES = {
+        65536, 1048576
+    };
     private final int transportBufferSize;
 
     public LargeFileTransferTest(String name, Map<String, String> properties, int transportBufferSize) {
@@ -53,19 +56,9 @@ public class LargeFileTransferTest extends BaseCIFSTest {
     @Parameters(name = "{0} - {2} bytes buffer")
     public static Collection<Object> configs() {
         List<Object> configs = new ArrayList<>();
-        String dialectFilter = System.getProperty("largeFileTransfer.dialects", "smb2,smb30,smb31");
-        String[] dialects = dialectFilter.split(",");
-        String filter = System.getProperty("largeFileTransfer.bufferSizes", "65536,1048576");
-        String[] parts = filter.split(",");
-        int[] bufferSizes = new int[parts.length];
-        for ( int i = 0; i < parts.length; i++ ) {
-            bufferSizes[ i ] = Integer.parseInt(parts[ i ].trim());
-        }
-
-        for (Object baseObj : getConfigs(dialects)) {
-
+        for ( Object baseObj : getConfigs("smb2", "smb30", "smb31") ) {
             Object[] base = (Object[]) baseObj;
-            for (int bufSize : bufferSizes) {
+            for ( int bufSize : BUFFER_SIZES ) {
                 configs.add(new Object[] { base[0] + "-" + bufSize, base[1], bufSize });
             }
         }
@@ -75,22 +68,10 @@ public class LargeFileTransferTest extends BaseCIFSTest {
     @Override
     @org.junit.Before
     public void setUp() throws Exception {
-        if ( !getProperties().containsKey("jcifs.smb.client.maxVersion") ) {
-            getProperties().put("jcifs.smb.client.maxVersion", "SMB311");
-        }
-        if ( !getProperties().containsKey("jcifs.smb.client.minVersion") ) {
-            getProperties().put("jcifs.smb.client.minVersion", "SMB202");
-        }
-        getProperties().put("jcifs.smb.client.useSMB2Negotiation", "true");
-        getProperties().put("jcifs.smb.client.dfs.disabled", "true");
-        getProperties().put("jcifs.smb.client.ipcSigningEnforced", "false");
-        getProperties().put("jcifs.smb.client.disablePlainTextPasswords", "false");
-        getProperties().put("jcifs.smb.useRawNTLM", "true");
-        
-        // Set the transport buffer size for this run
+        // Run through the shared test configuration machinery, varying only transport buffer sizing here.
         getProperties().put("jcifs.smb.client.snd_buf_size", String.valueOf(transportBufferSize));
         getProperties().put("jcifs.smb.client.rcv_buf_size", String.valueOf(transportBufferSize));
-        
+
         super.setUp();
     }
 


### PR DESCRIPTION
Enable real large-MTU SMB2/3 transfers in jcifs-ng by fixing both the client-side negotiate clamp and the SMB2 multi-credit message-id allocation.

Changes:
- remove the hardcoded 128 KiB clamp from SMB2 LARGE_MTU negotiation
- reserve SMB2 message ids according to CreditCharge for multi-credit requests instead of always advancing by one
- propagate SMB2 write RemainingBytes in SmbFileOutputStream
- keep large SMB2 read/write request padding aligned with size()

Tests:
- add filtering support to LargeFileTransferTest so single dialect / buffer-size cases can be run directly
- stop overriding dialect mutations in LargeFileTransferTest setup

Results against Synology DSM SMB server:
- negotiated maxReadSize/maxWriteSize now reach 1048576 instead of 131072
- multi-credit transfer test passes for smb2/smb30/smb31
- smb2 1 MiB test improved from 7.30/6.36 MB/s write/read (64 KiB single-credit baseline) to 26.17/37.67 MB/s (+258%/+492%)

Test command syntax is:
```
mvn -q -f pom.xml test \
    -Dtest=LargeFileTransferTest \
    -DlargeFileTransfer.bufferSizes=1048576 \
    -DlargeFileTransfer.dialects=smb2,smb30,smb31 \
    -Dtest.server=<server> \
    -Dtest.user.name=<username> \
    -Dtest.user.password=<password> \
    -Dtest.share.main=<share>
```