### PR TITLE
Ensure Locale.ROOT in NTLM uppercase conversions

### DIFF
--- a/src/main/java/jcifs/ntlmssp/Type1Message.java
+++ b/src/main/java/jcifs/ntlmssp/Type1Message.java
@@ -21,6 +21,7 @@ package jcifs.ntlmssp;
 
 
 import java.io.IOException;
+import java.util.Locale;
 
 import jcifs.CIFSContext;
 
@@ -144,7 +145,7 @@ public class Type1Message extends NtlmMessage {
             String suppliedDomainString = getSuppliedDomain();
             if ( ( flags & NTLMSSP_NEGOTIATE_VERSION ) == 0 && suppliedDomainString != null && suppliedDomainString.length() != 0 ) {
                 flags |= NTLMSSP_NEGOTIATE_OEM_DOMAIN_SUPPLIED;
-                domain = suppliedDomainString.toUpperCase().getBytes(getOEMEncoding());
+                domain = suppliedDomainString.toUpperCase(Locale.ROOT).getBytes(getOEMEncoding());
                 size += domain.length;
             }
             else {
@@ -155,7 +156,7 @@ public class Type1Message extends NtlmMessage {
             String suppliedWorkstationString = getSuppliedWorkstation();
             if ( ( flags & NTLMSSP_NEGOTIATE_VERSION ) == 0 && suppliedWorkstationString != null && suppliedWorkstationString.length() != 0 ) {
                 flags |= NTLMSSP_NEGOTIATE_OEM_WORKSTATION_SUPPLIED;
-                workstation = suppliedWorkstationString.toUpperCase().getBytes(getOEMEncoding());
+                workstation = suppliedWorkstationString.toUpperCase(Locale.ROOT).getBytes(getOEMEncoding());
                 size += workstation.length;
             }
             else {

--- a/src/main/java/jcifs/ntlmssp/Type2Message.java
+++ b/src/main/java/jcifs/ntlmssp/Type2Message.java
@@ -22,6 +22,7 @@ package jcifs.ntlmssp;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -332,7 +333,7 @@ public class Type2Message extends NtlmMessage {
         if ( getFlag(NTLMSSP_REQUEST_TARGET) ) {
             if ( targetName != null && targetName.length() != 0 ) {
                 targetBytes = ( flags & NTLMSSP_NEGOTIATE_UNICODE ) != 0 ? targetName.getBytes(UNI_ENCODING)
-                        : targetName.toUpperCase().getBytes(getOEMEncoding());
+                        : targetName.toUpperCase(Locale.ROOT).getBytes(getOEMEncoding());
                 size += targetBytes.length;
             }
             else {

--- a/src/main/java/jcifs/ntlmssp/Type3Message.java
+++ b/src/main/java/jcifs/ntlmssp/Type3Message.java
@@ -25,6 +25,7 @@ import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 
 import javax.crypto.Cipher;
 
@@ -626,14 +627,14 @@ public class Type3Message extends NtlmMessage {
         String userName = getUser();
         byte[] userBytes = null;
         if ( userName != null && userName.length() != 0 ) {
-            userBytes = unicode ? userName.getBytes(UNI_ENCODING) : userName.toUpperCase().getBytes(oemCp);
+            userBytes = unicode ? userName.getBytes(UNI_ENCODING) : userName.toUpperCase(Locale.ROOT).getBytes(oemCp);
             size += userBytes.length;
         }
 
         String workstationName = getWorkstation();
         byte[] workstationBytes = null;
         if ( workstationName != null && workstationName.length() != 0 ) {
-            workstationBytes = unicode ? workstationName.getBytes(UNI_ENCODING) : workstationName.toUpperCase().getBytes(oemCp);
+            workstationBytes = unicode ? workstationName.getBytes(UNI_ENCODING) : workstationName.toUpperCase(Locale.ROOT).getBytes(oemCp);
             size += workstationBytes.length;
         }
 

--- a/src/main/java/jcifs/smb/NtlmPasswordAuthenticator.java
+++ b/src/main/java/jcifs/smb/NtlmPasswordAuthenticator.java
@@ -25,6 +25,7 @@ import java.security.MessageDigest;
 import java.security.Principal;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 
@@ -351,8 +352,8 @@ public class NtlmPasswordAuthenticator implements Principal, CredentialsInternal
     public boolean equals ( Object obj ) {
         if ( obj instanceof NtlmPasswordAuthenticator ) {
             NtlmPasswordAuthenticator ntlm = (NtlmPasswordAuthenticator) obj;
-            String domA = ntlm.getUserDomain() != null ? ntlm.getUserDomain().toUpperCase() : null;
-            String domB = this.getUserDomain() != null ? this.getUserDomain().toUpperCase() : null;
+            String domA = ntlm.getUserDomain() != null ? ntlm.getUserDomain().toUpperCase(Locale.ROOT) : null;
+            String domB = this.getUserDomain() != null ? this.getUserDomain().toUpperCase(Locale.ROOT) : null;
             return ntlm.type == this.type && Objects.equals(domA, domB) && ntlm.getUsername().equalsIgnoreCase(this.getUsername())
                     && Objects.equals(getPassword(), ntlm.getPassword());
         }
@@ -365,7 +366,7 @@ public class NtlmPasswordAuthenticator implements Principal, CredentialsInternal
      */
     @Override
     public int hashCode () {
-        return getName().toUpperCase().hashCode();
+        return getName().toUpperCase(Locale.ROOT).hashCode();
     }
 
 
@@ -581,8 +582,8 @@ public class NtlmPasswordAuthenticator implements Principal, CredentialsInternal
                 }
 
                 MessageDigest hmac = Crypto.getHMACT64(ntHash);
-                hmac.update(Strings.getUNIBytes(this.username.toUpperCase()));
-                hmac.update(Strings.getUNIBytes(this.domain.toUpperCase()));
+                hmac.update(Strings.getUNIBytes(this.username.toUpperCase(Locale.ROOT)));
+                hmac.update(Strings.getUNIBytes(this.domain.toUpperCase(Locale.ROOT)));
                 byte[] ntlmv2Hash = hmac.digest();
                 hmac = Crypto.getHMACT64(ntlmv2Hash);
                 hmac.update(chlng);

--- a/src/main/java/jcifs/smb/NtlmUtil.java
+++ b/src/main/java/jcifs/smb/NtlmUtil.java
@@ -20,6 +20,7 @@ package jcifs.smb;
 
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
+import java.util.Locale;
 
 import javax.crypto.Cipher;
 import javax.crypto.ShortBufferException;
@@ -118,7 +119,7 @@ public final class NtlmUtil {
      */
     public static byte[] nTOWFv2 ( String domain, String username, byte[] passwordHash ) {
         MessageDigest hmac = Crypto.getHMACT64(passwordHash);
-        hmac.update(Strings.getUNIBytes(username.toUpperCase()));
+        hmac.update(Strings.getUNIBytes(username.toUpperCase(Locale.ROOT)));
         hmac.update(Strings.getUNIBytes(domain));
         return hmac.digest();
     }
@@ -214,8 +215,8 @@ public final class NtlmUtil {
             throws GeneralSecurityException {
         byte[] response = new byte[24];
         MessageDigest hmac = Crypto.getHMACT64(passwordHash);
-        hmac.update(Strings.getUNIBytes(user.toUpperCase()));
-        hmac.update(Strings.getUNIBytes(domain.toUpperCase()));
+        hmac.update(Strings.getUNIBytes(user.toUpperCase(Locale.ROOT)));
+        hmac.update(Strings.getUNIBytes(domain.toUpperCase(Locale.ROOT)));
         hmac = Crypto.getHMACT64(hmac.digest());
         hmac.update(challenge);
         hmac.update(clientChallenge);


### PR DESCRIPTION
Using String.toUpperCase() without Locale.ROOT causes character conversions to follow the host JVM's default locale. In locales such as Turkish (tr_TR), lowercase 'i' uppercases to dotted 'İ' (U+0130) rather than ASCII 'I' (U+0049). This corrupts the NTLMv2 hash calculation (NTOWFv2) and OEM Type 1/2/3 message encoding when usernames or domains contain 'i', causing Windows servers to reject valid credentials with STATUS_LOGON_FAILURE.

I had this issue with my nova video player android application preventing user to log in .
See https://github.com/nova-video-player/aos-AVP/issues/1927